### PR TITLE
Add support for generating javadoc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -57,6 +57,7 @@ stardoc(
         "assemble_gcp",
         "deploy_github",
         "assemble_maven",
+        "javadoc",
         "deploy_maven",
         "JavaLibInfo",
         "MavenDeploymentInfo",

--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,7 @@ JarToMavenCoordinatesMapping(<a href="#JarToMavenCoordinatesMapping-filename">fi
 ## JavaLibInfo
 
 <pre>
-JavaLibInfo(<a href="#JavaLibInfo-target_coordinates">target_coordinates</a>, <a href="#JavaLibInfo-target_deps_coordinates">target_deps_coordinates</a>)
+JavaLibInfo(<a href="#JavaLibInfo-target_coordinates">target_coordinates</a>, <a href="#JavaLibInfo-target_deps_coordinates">target_deps_coordinates</a>, <a href="#JavaLibInfo-srcs">srcs</a>)
 </pre>
 
 
@@ -1104,6 +1104,12 @@ JavaLibInfo(<a href="#JavaLibInfo-target_coordinates">target_coordinates</a>, <a
       <td>
         <p>The Maven coordinates of the direct dependencies, and the transitively exported targets, of
         this target.</p>
+      </td>
+    </tr>
+    <tr id="JavaLibInfo-srcs">
+      <td><code>srcs</code></td>
+      <td>
+        <p>The source files of the specified target.</p>
       </td>
     </tr>
   </tbody>

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -99,6 +99,7 @@ maven_url = deployment_properties['repo.maven.' + repo_type]
 jar_path = "$JAR_PATH"
 pom_file_path = "$POM_PATH"
 srcjar_path = "$SRCJAR_PATH"
+docjar_path = "$DOCJAR_PATH"
 
 namespace = { 'namespace': 'http://maven.apache.org/POM/4.0.0' }
 root = ElementTree.parse(pom_file_path).getroot()
@@ -143,10 +144,9 @@ if should_sign:
 upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
 if should_sign:
     upload(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
-# TODO(vmax): use real Javadoc instead of srcjar
-upload(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
+upload(maven_url, username, password, docjar_path, filename_base + '-javadoc.jar')
 if should_sign:
-    upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
+    upload(maven_url, username, password, sign(docjar_path), filename_base + '-javadoc.jar.asc')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_md5:
     pom_md5.write(md5(pom_file_path))
@@ -172,12 +172,18 @@ with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_md5:
     srcjar_md5.write(md5(srcjar_path))
     srcjar_md5.flush()
     upload(maven_url, username, password, srcjar_md5.name, filename_base + '-sources.jar.md5')
-    # TODO(vmax): use checksum of real Javadoc instead of srcjar
-    upload(maven_url, username, password, srcjar_md5.name, filename_base + '-javadoc.jar.md5')
+
+with tempfile.NamedTemporaryFile(mode='wt', delete=True) as docjar_md5:
+    docjar_md5.write(md5(docjar_path))
+    docjar_md5.flush()
+    upload(maven_url, username, password, docjar_md5.name, filename_base + '-javadoc.jar.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_sha1:
     srcjar_sha1.write(sha1(srcjar_path))
     srcjar_sha1.flush()
     upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-sources.jar.sha1')
-    # TODO(vmax): use checksum of real Javadoc instead of srcjar
-    upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-javadoc.jar.sha1')
+
+with tempfile.NamedTemporaryFile(mode='wt', delete=True) as docjar_sha1:
+    docjar_sha1.write(sha1(docjar_path))
+    docjar_sha1.flush()
+    upload(maven_url, username, password, docjar_sha1.name, filename_base + '-javadoc.jar.sha1')

--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -468,10 +468,22 @@ def _javadoc(ctx):
         src_list += [src.path]
 
     # https://docs.oracle.com/en/java/javase/11/javadoc/javadoc-command.html#GUID-B0079316-8AA3-475B-8276-6A4095B5186A
+    java_home = ctx.attr._jdk[java_common.JavaRuntimeInfo].java_home
     cmd = [
-        "mkdir -p %s" % maven_coordinates.artifact_id,
-        "%s/bin/javadoc -d %s %s" % (ctx.attr._jdk[java_common.JavaRuntimeInfo].java_home, maven_coordinates.artifact_id, " ".join(src_list)),
-        "jar cvf %s %s/*" % (output_jar.path, maven_coordinates.artifact_id),
+        "mkdir -p {}".format(maven_coordinates.artifact_id),
+        " ".join([
+            "{}/bin/javadoc".format(java_home),
+            "-Xdoclint:-missing",
+            "-encoding UTF-8",
+            "-charset UTF-8",
+            "-notimestamp",
+            "-quiet",
+            "-windowtitle 'Java documentation for {}'".format(ctx.attr.name),
+            "-doctitle 'Java documentation for {}'".format(ctx.attr.name),
+            "-d {}".format(maven_coordinates.artifact_id),
+            " ".join(src_list),
+        ]),
+        "{}/bin/jar cvf {} {}/*".format(java_home, output_jar.path, maven_coordinates.artifact_id),
     ]
 
     ctx.actions.run_shell(

--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -483,7 +483,8 @@ def _javadoc(ctx):
             "-d {}".format(maven_coordinates.artifact_id),
             " ".join(src_list),
         ]),
-        "{}/bin/jar cvf {} {}/*".format(java_home, output_jar.path, maven_coordinates.artifact_id),
+        "cd {}".format(maven_coordinates.artifact_id),
+        "../{}/bin/jar -cvf ../{} *".format(java_home, output_jar.path),
     ]
 
     ctx.actions.run_shell(


### PR DESCRIPTION
Please replace every line in curly brackets ( { like this } ) with an appropriate description, and remove this line.

## What is the goal of this PR?

Adds support for assembling Javadoc JARs and deploying them to Maven Central.

Closes #231

## What are the changes implemented in this PR?

- identify the referenced target's `srcs` files
- create a javadoc target which parses all `srcs` and generated docs
- run it as part of `assemble_maven`
- also, allow it to be run individually (e.g., if a developer wants to generate javadocs outside of the assemble target)
- updated the README to list the `srcs` entry