### PR TITLE
Fix JarAssembler to account for already-present prefix

### DIFF
--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -54,7 +54,11 @@ class JarAssembler : Callable<Unit> {
                         }
                         entryNames.add(entry.name)
                         BufferedInputStream(jarZip.getInputStream(entry)).use { inputStream ->
-                            val newEntry = ZipEntry(prefix + entry.name)
+                            var name = entry.name
+                            if (!name.startsWith(prefix)) {
+                                name = prefix + name;
+                            }
+                            val newEntry = ZipEntry(name)
                             out.putNextEntry(newEntry)
                             inputStream.copyTo(out, 1024)
                         }


### PR DESCRIPTION
## What is the goal of this PR?

Allow assembling source JARs where sources or them come from mixed sources (both generated and hand-written).

## What are the changes implemented in this PR?

Only prepend `source_jar_prefix` if it's not already present; this way, for Grabl Tracing library these changes are made (with `source_jar_prefix` = `grabl/tracing/`):

`protocol/util/ProtobufUUIDUtil.java` => `grabl/tracing/protocol/util/ProtobufUUIDUtil.java` (prefix added as it was not there before)
`grabl/tracing/protocol/TracingProto.java` => `grabl/tracing/protocol/TracingProto.java` (not modified as it already contains the correct prefix)

Fix #298

