### PR TITLE
Fix assemble_maven to produce correct JARs

### DIFF
--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -89,8 +89,8 @@ class JarAssembler : Callable<Unit> {
             }
             entries.keys.sorted().forEach {
                 val newEntry = ZipEntry(it)
-                out.write(entries[it]!!)
                 out.putNextEntry(newEntry)
+                out.write(entries[it]!!)
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Make JARs produced by `assemble_maven` correct

## What are the changes implemented in this PR?

Put `ZipEntry` into the archive _before_ writing file contents