### PR TITLE
Fix assemble_maven to produce valid source JARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ## assemble_maven
 
 <pre>
-assemble_maven(<a href="#assemble_maven-name">name</a>, <a href="#assemble_maven-developers">developers</a>, <a href="#assemble_maven-license">license</a>, <a href="#assemble_maven-package">package</a>, <a href="#assemble_maven-project_description">project_description</a>, <a href="#assemble_maven-project_name">project_name</a>, <a href="#assemble_maven-project_url">project_url</a>,
-               <a href="#assemble_maven-scm_url">scm_url</a>, <a href="#assemble_maven-target">target</a>, <a href="#assemble_maven-version_file">version_file</a>, <a href="#assemble_maven-version_overrides">version_overrides</a>, <a href="#assemble_maven-workspace_refs">workspace_refs</a>)
+assemble_maven(<a href="#assemble_maven-name">name</a>, <a href="#assemble_maven-license">license</a>, <a href="#assemble_maven-project_description">project_description</a>, <a href="#assemble_maven-project_name">project_name</a>, <a href="#assemble_maven-project_url">project_url</a>, <a href="#assemble_maven-scm_url">scm_url</a>, <a href="#assemble_maven-target">target</a>,
+               <a href="#assemble_maven-version_file">version_file</a>, <a href="#assemble_maven-version_overrides">version_overrides</a>, <a href="#assemble_maven-workspace_refs">workspace_refs</a>)
 </pre>
 
 Assemble Java package for subsequent deployment to Maven repo
@@ -17,9 +17,7 @@ Assemble Java package for subsequent deployment to Maven repo
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="assemble_maven-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="assemble_maven-developers"></a>developers |  Project developers to fill into pom.xml   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | optional | {} |
 | <a id="assemble_maven-license"></a>license |  Project license to fill into pom.xml   | String | optional | "apache" |
-| <a id="assemble_maven-package"></a>package |  Bazel package of this target. Must match one defined in <code>_maven_packages</code>   | String | optional | "" |
 | <a id="assemble_maven-project_description"></a>project_description |  Project description to fill into pom.xml   | String | optional | "PROJECT_DESCRIPTION" |
 | <a id="assemble_maven-project_name"></a>project_name |  Project name to fill into pom.xml   | String | optional | "PROJECT_NAME" |
 | <a id="assemble_maven-project_url"></a>project_url |  Project URL to fill into pom.xml   | String | optional | "PROJECT_URL" |
@@ -239,7 +237,7 @@ deploy_npm(<a href="#deploy_npm-name">name</a>, <a href="#deploy_npm-release">re
 ## deploy_packer
 
 <pre>
-deploy_packer(<a href="#deploy_packer-name">name</a>, <a href="#deploy_packer-target">target</a>)
+deploy_packer(<a href="#deploy_packer-name">name</a>, <a href="#deploy_packer-overwrite">overwrite</a>, <a href="#deploy_packer-target">target</a>)
 </pre>
 
 Execute Packer to perform deployment
@@ -250,6 +248,7 @@ Execute Packer to perform deployment
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="deploy_packer-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="deploy_packer-overwrite"></a>overwrite |  Overwrite already-existing image   | Boolean | optional | False |
 | <a id="deploy_packer-target"></a>target |  <code>assemble_packer</code> label to be deployed.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
@@ -379,25 +378,6 @@ JarToMavenCoordinatesMapping(<a href="#JarToMavenCoordinatesMapping-filename">fi
 | <a id="JarToMavenCoordinatesMapping-maven_coordinates"></a>maven_coordinates |  Maven coordinates of the jar    |
 
 
-<a id="#JavaLibInfo"></a>
-
-## JavaLibInfo
-
-<pre>
-JavaLibInfo(<a href="#JavaLibInfo-target_coordinates">target_coordinates</a>, <a href="#JavaLibInfo-target_deps_coordinates">target_deps_coordinates</a>)
-</pre>
-
-
-
-**FIELDS**
-
-
-| Name  | Description |
-| :------------- | :------------- |
-| <a id="JavaLibInfo-target_coordinates"></a>target_coordinates |  The Maven coordinates for the artifacts that are exported by this target: i.e. the target         itself and its transitively exported targets.    |
-| <a id="JavaLibInfo-target_deps_coordinates"></a>target_deps_coordinates |  The Maven coordinates of the direct dependencies, and the transitively exported targets, of         this target.    |
-
-
 <a id="#MavenDeploymentInfo"></a>
 
 ## MavenDeploymentInfo
@@ -416,25 +396,6 @@ MavenDeploymentInfo(<a href="#MavenDeploymentInfo-jar">jar</a>, <a href="#MavenD
 | <a id="MavenDeploymentInfo-jar"></a>jar |  JAR file to deploy    |
 | <a id="MavenDeploymentInfo-srcjar"></a>srcjar |  JAR file with sources    |
 | <a id="MavenDeploymentInfo-pom"></a>pom |  Accompanying pom.xml file    |
-
-
-<a id="#MavenPomInfo"></a>
-
-## MavenPomInfo
-
-<pre>
-MavenPomInfo(<a href="#MavenPomInfo-direct_pom_deps">direct_pom_deps</a>, <a href="#MavenPomInfo-transitive_pom_deps">transitive_pom_deps</a>)
-</pre>
-
-
-
-**FIELDS**
-
-
-| Name  | Description |
-| :------------- | :------------- |
-| <a id="MavenPomInfo-direct_pom_deps"></a>direct_pom_deps |  Maven coordinates declared directly by a target    |
-| <a id="MavenPomInfo-transitive_pom_deps"></a>transitive_pom_deps |  Maven coordinates for dependencies, transitively collected    |
 
 
 <a id="#TransitiveJarToMavenCoordinatesMapping"></a>

--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -5,6 +5,11 @@ import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.lang.RuntimeException
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.*
 import java.util.concurrent.Callable
 import java.util.zip.ZipEntry
@@ -15,12 +20,10 @@ import kotlin.system.exitProcess
 
 @Command(name = "jar-assembler", mixinStandardHelpOptions = true)
 class JarAssembler : Callable<Unit> {
+    val javaPackageRegex = Regex("package\\s+([a-zA_Z_][\\.\\w]*);")
 
     @Option(names = ["--output"], required = true)
     lateinit var output_file: File
-
-    @Option(names = ["--prefix"])
-    lateinit var prefix: String
 
     @Option(names = ["--group-id"])
     var groupId = ""
@@ -34,32 +37,61 @@ class JarAssembler : Callable<Unit> {
     @Option(names = ["--jars"], split = ";")
     lateinit var jars: Array<File>
 
-    val entryNames = mutableSetOf<String>()
+    private val entryNames = mutableSetOf<String>()
+    val entries = HashMap<String, ByteArray>()
+
+    /**
+     * For path "a/b/c.java" inserts "a/" and "a/b/ into `entries`
+     */
+    private fun addDirectories(path: Path) {
+        for (i in path.nameCount-1 downTo 1) {
+            val subPath = path.subpath(0, i).toString() + "/"
+            entries[subPath] = ByteArray(0)
+        }
+    }
 
     override fun call() {
         ZipOutputStream(BufferedOutputStream(FileOutputStream(output_file))).use { out ->
             if (pomFile != null) {
-                val pomFileEntry = ZipEntry("META-INF/maven/${groupId}/${artifactId}/pom.xml")
-                out.putNextEntry(pomFileEntry)
-                out.write(pomFile!!.readBytes())
+                val pomPath = "META-INF/maven/${groupId}/${artifactId}/pom.xml"
+                entries[pomPath] = pomFile!!.readBytes()
+                addDirectories(Paths.get(pomPath))
             }
             for (jar in jars) {
                 ZipFile(jar).use { jarZip ->
                     jarZip.entries().asSequence().forEach { entry ->
                         if (entry.name.contains("META-INF")) {
+                            // pom.xml will be added by us
                             return@forEach
                         }
                         if (entryNames.contains(entry.name)) {
+                            throw RuntimeException("duplicate entry in the JAR: ${entry.name}")
+                        }
+                        if (entry.isDirectory) {
+                            // needed directories would be added by us
                             return@forEach
                         }
                         entryNames.add(entry.name)
                         BufferedInputStream(jarZip.getInputStream(entry)).use { inputStream ->
-                            val newEntry = ZipEntry(prefix + entry.name)
-                            out.putNextEntry(newEntry)
-                            inputStream.copyTo(out, 1024)
+                            val sourceFileBytes = inputStream.readBytes()
+                            val sourceFile = sourceFileBytes.toString(Charset.forName("UTF-8"))
+                            var resultLocation = entry.name
+                            // files in source JARs are moved according to their `package` statement
+                            if (entry.name.endsWith(".java")) {
+                                val sourceFileName = Paths.get(entry.name).fileName.toString()
+                                val sourceFilePackage = javaPackageRegex.find(sourceFile)?.groups?.get(1)?.value ?: throw RuntimeException("could not obtain package of ${entry.name}")
+                                resultLocation = "${sourceFilePackage.replace(".", "/")}/$sourceFileName"
+                            }
+                            entries[resultLocation] = sourceFileBytes
+                            addDirectories(Paths.get(resultLocation))
                         }
                     }
                 }
+            }
+            entries.keys.sorted().forEach {
+                val newEntry = ZipEntry(it)
+                out.putNextEntry(newEntry)
+                out.write(entries[it]!!)
             }
         }
     }

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -100,7 +100,6 @@ def _generate_class_jar(ctx, pom_file):
         inputs = [jar, pom_file] + class_jar_deps,
         outputs = [output_jar],
         arguments = [
-            "--prefix=",  # prefix is deliberately left empty
             "--group-id=" + maven_coordinates.group_id,
             "--artifact-id=" + maven_coordinates.artifact_id,
             "--pom-file=" + pom_file.path,
@@ -138,7 +137,6 @@ def _generate_source_jar(ctx):
         inputs = [srcjar] + source_jar_deps,
         outputs = [output_jar],
         arguments = [
-            "--prefix=" + ctx.attr.source_jar_prefix,
             "--jars=" + ";".join(source_jar_paths),
             "--output=" + output_jar.path,
         ],
@@ -227,10 +225,6 @@ assemble_maven = rule(
                 aggregate_dependency_info,
             ],
             doc = "Java target for subsequent deployment",
-        ),
-        "source_jar_prefix": attr.string(
-            default = "",
-            doc = "Prefix source JAR files with this directory",
         ),
         "version_file": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
## What is the goal of this PR?

Allow assembling source JARs where sources or them come from mixed sources (both generated and hand-written).

## What are the changes implemented in this PR?

Modify `JarAssembler` to place files inside of source JAR according to the `package` statement in the source file. This allows us to produce always-correct source JARs as well as eliminates the need for passing `source_jar_prefix`

Fix #298 
