### PR TITLE
Refactor assemble_zip rule to be consistent with assemble_targz

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Packs Java library alongside with its dependencies into archive
 ## tgz2zip
 
 <pre>
-tgz2zip(<a href="#tgz2zip-name">name</a>, <a href="#tgz2zip-output_filename">output_filename</a>, <a href="#tgz2zip-prefix">prefix</a>, <a href="#tgz2zip-prefix_file">prefix_file</a>, <a href="#tgz2zip-tgz">tgz</a>)
+tgz2zip(<a href="#tgz2zip-name">name</a>, <a href="#tgz2zip-output_filename">output_filename</a>, <a href="#tgz2zip-tgz">tgz</a>)
 </pre>
 
 Converts .tar.gz into .zip
@@ -354,8 +354,6 @@ Converts .tar.gz into .zip
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="tgz2zip-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="tgz2zip-output_filename"></a>output_filename |  Resulting filename   | String | required |  |
-| <a id="tgz2zip-prefix"></a>prefix |  Prefix of files in archive   | String | optional | "" |
-| <a id="tgz2zip-prefix_file"></a>prefix_file |  Prefix of files in archive (as a file)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="tgz2zip-tgz"></a>tgz |  Input .tar.gz archive   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
@@ -606,7 +604,7 @@ Assemble distribution archive (.tar.gz)
 
 <pre>
 assemble_zip(<a href="#assemble_zip-name">name</a>, <a href="#assemble_zip-output_filename">output_filename</a>, <a href="#assemble_zip-targets">targets</a>, <a href="#assemble_zip-additional_files">additional_files</a>, <a href="#assemble_zip-empty_directories">empty_directories</a>, <a href="#assemble_zip-permissions">permissions</a>,
-             <a href="#assemble_zip-append_version">append_version</a>, <a href="#assemble_zip-visibility">visibility</a>)
+             <a href="#assemble_zip-append_version">append_version</a>, <a href="#assemble_zip-visibility">visibility</a>, <a href="#assemble_zip-tags">tags</a>)
 </pre>
 
 Assemble distribution archive (.zip)
@@ -618,11 +616,12 @@ Assemble distribution archive (.zip)
 | :------------- | :------------- | :------------- |
 | <a id="assemble_zip-name"></a>name |  A unique name for this target.   |  none |
 | <a id="assemble_zip-output_filename"></a>output_filename |  filename of resulting archive   |  none |
-| <a id="assemble_zip-targets"></a>targets |  Bazel labels of archives that go into .tar.gz package   |  none |
+| <a id="assemble_zip-targets"></a>targets |  Bazel labels of archives that go into .tar.gz package   |  <code>[]</code> |
 | <a id="assemble_zip-additional_files"></a>additional_files |  mapping between Bazel labels of files that go into archive     and their resulting location in archive   |  <code>{}</code> |
 | <a id="assemble_zip-empty_directories"></a>empty_directories |  list of empty directories created at archive installation   |  <code>[]</code> |
 | <a id="assemble_zip-permissions"></a>permissions |  mapping between paths and UNIX permissions   |  <code>{}</code> |
 | <a id="assemble_zip-append_version"></a>append_version |  append version to root folder inside the archive   |  <code>True</code> |
 | <a id="assemble_zip-visibility"></a>visibility |  controls whether the target can be used by other packages   |  <code>["//visibility:private"]</code> |
+| <a id="assemble_zip-tags"></a>tags |  <p align="center"> - </p>   |  <code>[]</code> |
 
 

--- a/common/targz/rules.bzl
+++ b/common/targz/rules.bzl
@@ -19,7 +19,6 @@
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@vaticle_bazel_distribution//common/java_deps:rules.bzl", "java_deps")
-load("@vaticle_bazel_distribution//common/zip:rules.bzl", "assemble_zip")
 
 def _assemble_targz_package_dir_file_impl(ctx):
     version = ctx.var.get('version', '')

--- a/common/tgz2zip/rules.bzl
+++ b/common/tgz2zip/rules.bzl
@@ -18,21 +18,11 @@
 #
 
 def _tgz2zip_impl(ctx):
-    files = [ctx.file.tgz]
-
-    if ctx.attr.prefix_file:
-        if ctx.attr.prefix:
-            fail("Both prefix and prefix_file attributes were specified")
-        prefix_arg = "@" + ctx.file.prefix_file.path
-        files.append(ctx.file.prefix_file)
-    else:
-        prefix_arg = ctx.attr.prefix or "."
-
     ctx.actions.run(
-        inputs = files,
+        inputs = [ctx.file.tgz],
         outputs = [ctx.outputs.zip],
         executable = ctx.executable._tgz2zip_py,
-        arguments = [ctx.file.tgz.path, ctx.outputs.zip.path, prefix_arg],
+        arguments = [ctx.file.tgz.path, ctx.outputs.zip.path],
         progress_message = "Converting {} to {}".format(ctx.file.tgz.short_path, ctx.outputs.zip.short_path)
     )
 
@@ -49,13 +39,6 @@ tgz2zip = rule(
         "output_filename": attr.string(
             mandatory = True,
             doc = 'Resulting filename'
-        ),
-        "prefix": attr.string(
-            doc = 'Prefix of files in archive'
-        ),
-        "prefix_file": attr.label(
-            doc = 'Prefix of files in archive (as a file)',
-            allow_single_file = True
         ),
         "_tgz2zip_py": attr.label(
             default = "//common/tgz2zip",

--- a/common/tgz2zip/tgz2zip.py
+++ b/common/tgz2zip/tgz2zip.py
@@ -27,12 +27,7 @@ import sys
 import zipfile
 import tarfile
 
-_, tgz_fn, zip_fn, prefix = sys.argv
-
-if prefix.startswith('@'):
-    fn = prefix.replace('@', '')
-    with open(fn) as prefix_file:
-      prefix = prefix_file.read().strip()
+_, tgz_fn, zip_fn = sys.argv
 
 
 with tarfile.open(tgz_fn, mode='r:gz') as tgz:
@@ -40,7 +35,7 @@ with tarfile.open(tgz_fn, mode='r:gz') as tgz:
         for tarinfo in sorted(tgz.getmembers(), key=lambda x: x.name):
             f = ''
             is_dir = tarinfo.isdir()
-            name = os.path.normpath(os.path.join(prefix, tarinfo.name))
+            name = tarinfo.name
             if not is_dir:
                 f = tgz.extractfile(tarinfo).read()
             else:
@@ -54,4 +49,3 @@ with tarfile.open(tgz_fn, mode='r:gz') as tgz:
                 # in macOS's Finder
                 zi.external_attr |= (stat.S_IFREG << 16)
             zip.writestr(zi, f)
-

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@vaticle_bazel_distribution//common/targz:rules.bzl", "assemble_targz")
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -16,6 +16,7 @@
 #
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@vaticle_bazel_distribution//common/targz:rules.bzl", "assemble_targz")
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 
 def _assemble_archive_prefix_file_impl(ctx):
@@ -43,7 +44,7 @@ assemble_zip_prefix_file = rule(
 )
 
 def assemble_zip(name,
-                 output_filename = None,
+                 output_filename,
                  targets = [],
                  additional_files = {},
                  empty_directories = [],
@@ -64,29 +65,20 @@ def assemble_zip(name,
         append_version: append version to root folder inside the archive
         visibility: controls whether the target can be used by other packages
     """
-    if output_filename == None:
-        output_filename = name
-    pkg_tar(
-        name="{}__do_not_reference__targz".format(name),
-        deps = targets,
-        extension = "tar.gz",
-        files = additional_files,
-        empty_dirs = empty_directories,
-        modes = permissions,
-        tags = tags
+    assemble_targz(
+        name = "{}__do_not_reference__targz".format(name),
+        output_filename = output_filename,
+        targets = targets,
+        additional_files = additional_files,
+        empty_directories = empty_directories,
+        permissions = permissions,
+        append_version = append_version,
+        visibility = ["//visibility:private"],
     )
-
-    assemble_zip_prefix_file(
-        name = "{}__do_not_reference__prefix_file".format(name),
-        prefix = "./" + output_filename,
-        append_version = append_version
-    )
-
     tgz2zip(
         name = name,
         tgz = ":{}__do_not_reference__targz".format(name),
         output_filename = output_filename,
-        prefix_file = "{}__do_not_reference__prefix_file".format(name),
         visibility = visibility,
         tags = tags
     )

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -19,39 +19,16 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@vaticle_bazel_distribution//common/targz:rules.bzl", "assemble_targz")
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 
-def _assemble_archive_prefix_file_impl(ctx):
-    version = ctx.var.get('version', '')
-
-    prefix = ctx.attr.prefix
-    if prefix and version and ctx.attr.append_version:
-        prefix = '{}-{}'.format(prefix, version)
-
-    ctx.actions.run_shell(
-        inputs = [],
-        outputs = [ctx.outputs.prefix_file],
-        command = "echo {} > {}".format(prefix, ctx.outputs.prefix_file.path)
-    )
-
-assemble_zip_prefix_file = rule(
-    attrs = {
-        "append_version": attr.bool(default=True),
-        "prefix": attr.string()
-    },
-    outputs = {
-        "prefix_file": "%{name}.prefix"
-    },
-    implementation = _assemble_archive_prefix_file_impl
-)
-
-def assemble_zip(name,
-                 output_filename,
-                 targets = [],
-                 additional_files = {},
-                 empty_directories = [],
-                 permissions = {},
-                 append_version = True,
-                 visibility = ["//visibility:private"],
-                 tags = []):
+def assemble_zip(
+        name,
+        output_filename,
+        targets = [],
+        additional_files = {},
+        empty_directories = [],
+        permissions = {},
+        append_version = True,
+        visibility = ["//visibility:private"],
+        tags = []):
     """Assemble distribution archive (.zip)
 
     Args:
@@ -80,7 +57,5 @@ def assemble_zip(name,
         tgz = ":{}__do_not_reference__targz".format(name),
         output_filename = output_filename,
         visibility = visibility,
-        tags = tags
+        tags = tags,
     )
-
-


### PR DESCRIPTION
## What is the goal of this PR?

Ensure behaviour of `assemble_zip` is consistent with `assemble_targz` by relying on it to do the actual work.

## What are the changes implemented in this PR?

Fix #306 

* Rely on `assemble_targz` for `assemble_zip` implementation
* Modify `tgz2zip` to not modify the archive structure and just do the repacking