### PR TITLE
Allow passing custom disk size when generating Azure images

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,10 +473,10 @@ Assemble files for AWS deployment
 
 <pre>
 assemble_azure(<a href="#assemble_azure-name">name</a>, <a href="#assemble_azure-image_name">image_name</a>, <a href="#assemble_azure-resource_group_name">resource_group_name</a>, <a href="#assemble_azure-install">install</a>, <a href="#assemble_azure-image_publisher">image_publisher</a>, <a href="#assemble_azure-image_offer">image_offer</a>,
-               <a href="#assemble_azure-image_sku">image_sku</a>, <a href="#assemble_azure-files">files</a>)
+               <a href="#assemble_azure-image_sku">image_sku</a>, <a href="#assemble_azure-disk_size_gb">disk_size_gb</a>, <a href="#assemble_azure-files">files</a>)
 </pre>
 
-Assemble files for GCP deployment
+Assemble files for Azure deployment
 
 **PARAMETERS**
 
@@ -487,9 +487,10 @@ Assemble files for GCP deployment
 | <a id="assemble_azure-image_name"></a>image_name |  name of deployed image   |  none |
 | <a id="assemble_azure-resource_group_name"></a>resource_group_name |  name of the resource group to place image in   |  none |
 | <a id="assemble_azure-install"></a>install |  Bazel label for install file   |  none |
-| <a id="assemble_azure-image_publisher"></a>image_publisher |  <p align="center"> - </p>   |  <code>"Canonical"</code> |
-| <a id="assemble_azure-image_offer"></a>image_offer |  <p align="center"> - </p>   |  <code>"0001-com-ubuntu-server-focal"</code> |
-| <a id="assemble_azure-image_sku"></a>image_sku |  <p align="center"> - </p>   |  <code>"20_04-lts"</code> |
+| <a id="assemble_azure-image_publisher"></a>image_publisher |  Publisher of the image used as base   |  <code>"Canonical"</code> |
+| <a id="assemble_azure-image_offer"></a>image_offer |  Offer of the image used as base   |  <code>"0001-com-ubuntu-server-focal"</code> |
+| <a id="assemble_azure-image_sku"></a>image_sku |  SKU of the image used as base   |  <code>"20_04-lts"</code> |
+| <a id="assemble_azure-disk_size_gb"></a>disk_size_gb |  Size of the resulting OS disk   |  <code>60</code> |
 | <a id="assemble_azure-files"></a>files |  Files to include into Azure deployment   |  <code>None</code> |
 
 

--- a/azure/packer.template.json
+++ b/azure/packer.template.json
@@ -18,7 +18,8 @@
       "image_offer": "{image_offer}",
       "image_sku": "{image_sku}",
       "build_resource_group_name": "{resource_group_name}",
-      "vm_size": "Standard_B2s"
+      "vm_size": "Standard_B2s",
+      "os_disk_size_gb": "{disk_size_gb}"
     }
   ],
 

--- a/azure/rules.bzl
+++ b/azure/rules.bzl
@@ -27,14 +27,19 @@ def assemble_azure(name,
                    image_publisher="Canonical",
                    image_offer="0001-com-ubuntu-server-focal",
                    image_sku="20_04-lts",
+                   disk_size_gb=60,
                    files=None):
-    """Assemble files for GCP deployment
+    """Assemble files for Azure deployment
 
     Args:
         name: A unique name for this target.
         image_name: name of deployed image
         resource_group_name: name of the resource group to place image in
         install: Bazel label for install file
+        image_publisher: Publisher of the image used as base
+        image_offer: Offer of the image used as base
+        image_sku: SKU of the image used as base
+        disk_size_gb: Size of the resulting OS disk
         files: Files to include into Azure deployment
     """
     if not files:
@@ -51,6 +56,7 @@ def assemble_azure(name,
             "{image_publisher}": image_publisher,
             "{image_offer}": image_offer,
             "{image_sku}": image_sku,
+            "{disk_size_gb}": str(disk_size_gb),
         }
     )
     files[install] = install_fn


### PR DESCRIPTION
## What is the goal of this PR?

Allow users to generate Azure images with increased OS disk size.

## What are the changes implemented in this PR?

Take in `disk_size_gb` argument and pass it down to Azure template. Example usage:

```
assemble_azure(
    name = "assemble-vaticle-ubuntu",
    install = "//infrastructure/common/images:ubuntu",
    image_name = "vaticle-ubuntu-{{user `version`}}",
    resource_group_name = "grabl-common",
    files = {
        "//automation/job/timeout:job-timeout_deploy.jar": "job-timeout.jar"
    },
    disk_size_gb = 60,
)
```