### PR TITLE
Normalize paths when assembling ZIP archives

### DIFF
--- a/common/tgz2zip/tgz2zip.py
+++ b/common/tgz2zip/tgz2zip.py
@@ -36,8 +36,6 @@ with tarfile.open(tgz_fn, mode='r:gz') as tgz:
             f = ''
             is_dir = tarinfo.isdir()
             name = os.path.normpath(tarinfo.name)
-            if name == '.':
-                continue
             if not is_dir:
                 f = tgz.extractfile(tarinfo).read()
             else:

--- a/common/tgz2zip/tgz2zip.py
+++ b/common/tgz2zip/tgz2zip.py
@@ -35,7 +35,9 @@ with tarfile.open(tgz_fn, mode='r:gz') as tgz:
         for tarinfo in sorted(tgz.getmembers(), key=lambda x: x.name):
             f = ''
             is_dir = tarinfo.isdir()
-            name = tarinfo.name
+            name = os.path.normpath(tarinfo.name)
+            if name == '.':
+                continue
             if not is_dir:
                 f = tgz.extractfile(tarinfo).read()
             else:


### PR DESCRIPTION
## What is the goal of this PR?

Make archives assembled by `assemble_zip` rule unpackable on Windows.

## What are the changes implemented in this PR?

Normalize paths when assembling ZIP archives, which means `./typedb-all-windows/typedb.bat` would become `typedb-all-windows/typedb.bat`

Fix #315
