### PR TITLE
Fix `SNAPSHOT` uploads for Artifactory repositories

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -130,12 +130,12 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
     coordinates=group_id.text.replace('.', '/'), version=version, artifact=artifact_id.text)
 
-upload(maven_url, username, password, pom_file_path, filename_base + '.pom')
-if should_sign:
-    upload(maven_url, username, password, sign(pom_file_path), filename_base + '.pom.asc')
 upload(maven_url, username, password, jar_path, filename_base + '.jar')
 if should_sign:
     upload(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
+upload(maven_url, username, password, pom_file_path, filename_base + '.pom')
+if should_sign:
+    upload(maven_url, username, password, sign(pom_file_path), filename_base + '.pom.asc')
 if os.path.exists(srcjar_path):
     upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
     if should_sign:


### PR DESCRIPTION
## What is the goal of this PR?

Fix `SNAPSHOT` uploads for Artifactory repositories. Due to the order of upload, Artifactory would expand the `SNAPSHOT` differently for the POM and JAR artifacts, resulting in mismatched artifacts:

![Screen Shot 2021-09-16 at 2 13 05 PM](https://user-images.githubusercontent.com/9255651/133670956-ea2c3b9b-4543-49df-b9de-3de3971072ae.png)

You can see that the POM version `SNAPSHOT` resolved to `20210916.163241-1` and the JAR version `SNAPSHOT` resolved to `20210916.163242-2`. Furthermore, the POM checksum uploads would fail as they would be attempted to upload for the latest SNAPSHOT, `20210916.163242-2`, which wouldn't exist:

```
Target file to set checksum on doesn't exist: MySnapshotRepo:com/example/bazel/plugin/0.0.9canary13-SNAPSHOT/plugin-0.0.9canary13-20210916.163242-2.pom
```

## What are the changes implemented in this PR?

Uploading the JAR artifact first fixes this issue and didn't affect uploads to release repositories.

![Screen Shot 2021-09-16 at 2 21 25 PM](https://user-images.githubusercontent.com/9255651/133671827-d23ba544-adc5-40f4-8862-fde6ca27f397.png)

