### PR TITLE
Allow empty maven deps_coordinates

### DIFF
--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -49,8 +49,8 @@ class PomGenerator : Callable<Unit> {
     @Option(names = ["--target_artifact_id"])
     var targetArtifactId = ""
 
-    @Option(names = ["--target_deps_coordinates"], split = ";")
-    lateinit var dependencyCoordinates: Array<String>
+    @Option(names = ["--target_deps_coordinates"])
+    lateinit var dependencyCoordinates: String
 
     fun getLicenseInfo(license_id: String): Pair<String, String> {
         return when {
@@ -120,7 +120,8 @@ class PomGenerator : Callable<Unit> {
 
     fun dependencies(pom: Document, version: String, workspace_refs: JsonObject): Element {
         val dependenciesElem = pom.createElement("dependencies")
-        for (dep in dependencyCoordinates) {
+        val coordinates = if (dependencyCoordinates.length == 0) emptyArray<String>() else dependencyCoordinates.split(";").toTypedArray()
+        for (dep in coordinates) {
             val depCoordinates = parseMavenCoordinate(dep)
             val dependencyElem = pom.createElement("dependency")
 


### PR DESCRIPTION
## What is the goal of this PR?

Some maven libraries don't have have further dependencies, which caused assemble_maven and pom_generator to fail. This change allows us to handle empty lists of maven dependencies during POM generation.

## What are the changes implemented in this PR?
* Discover that the `--target_deps_coordinates` option that split by `;` automatically produces a list with an empty element when given an empty string --  we want to get an empty list, rather than a list with an empty element
* Implement the above change by manually processing the provided list