### PR TITLE
Automatically collect crate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <pre>
 assemble_crate(<a href="#assemble_crate-name">name</a>, <a href="#assemble_crate-authors">authors</a>, <a href="#assemble_crate-categories">categories</a>, <a href="#assemble_crate-description">description</a>, <a href="#assemble_crate-documentation">documentation</a>, <a href="#assemble_crate-homepage">homepage</a>, <a href="#assemble_crate-keywords">keywords</a>, <a href="#assemble_crate-license">license</a>,
-               <a href="#assemble_crate-mapping">mapping</a>, <a href="#assemble_crate-readme_file">readme_file</a>, <a href="#assemble_crate-repository">repository</a>, <a href="#assemble_crate-target">target</a>, <a href="#assemble_crate-version_file">version_file</a>)
+               <a href="#assemble_crate-readme_file">readme_file</a>, <a href="#assemble_crate-repository">repository</a>, <a href="#assemble_crate-target">target</a>, <a href="#assemble_crate-version_file">version_file</a>)
 </pre>
 
 
@@ -24,7 +24,6 @@ assemble_crate(<a href="#assemble_crate-name">name</a>, <a href="#assemble_crate
 | <a id="assemble_crate-homepage"></a>homepage |  Link to homepage of the project   | String | required |  |
 | <a id="assemble_crate-keywords"></a>keywords |  The keywords field is an array of strings that describe this package.             This can help when searching for the package on a registry, and you may choose any words that would help someone find this crate.<br><br>            Note: crates.io has a maximum of 5 keywords.             Each keyword must be ASCII text, start with a letter, and only contain letters, numbers, _ or -, and have at most 20 characters.<br><br>            https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field   | List of strings | optional | [] |
 | <a id="assemble_crate-license"></a>license |  The license field contains the name of the software license that the package is released under.             https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields   | String | required |  |
-| <a id="assemble_crate-mapping"></a>mapping |  Maps Bazel target name to a real crate name, for example:             { "antlr_rust": "antlr-rust" }   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="assemble_crate-readme_file"></a>readme_file |  README of the project   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="assemble_crate-repository"></a>repository |  Repository of the project   | String | required |  |
 | <a id="assemble_crate-target"></a>target |  <code>rust_library</code> label to be included in the package   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ## assemble_crate
 
 <pre>
-assemble_crate(<a href="#assemble_crate-name">name</a>, <a href="#assemble_crate-authors">authors</a>, <a href="#assemble_crate-categories">categories</a>, <a href="#assemble_crate-deps">deps</a>, <a href="#assemble_crate-description">description</a>, <a href="#assemble_crate-documentation">documentation</a>, <a href="#assemble_crate-homepage">homepage</a>, <a href="#assemble_crate-keywords">keywords</a>,
-               <a href="#assemble_crate-license">license</a>, <a href="#assemble_crate-readme_file">readme_file</a>, <a href="#assemble_crate-repository">repository</a>, <a href="#assemble_crate-target">target</a>, <a href="#assemble_crate-version_file">version_file</a>)
+assemble_crate(<a href="#assemble_crate-name">name</a>, <a href="#assemble_crate-authors">authors</a>, <a href="#assemble_crate-categories">categories</a>, <a href="#assemble_crate-description">description</a>, <a href="#assemble_crate-documentation">documentation</a>, <a href="#assemble_crate-homepage">homepage</a>, <a href="#assemble_crate-keywords">keywords</a>, <a href="#assemble_crate-license">license</a>,
+               <a href="#assemble_crate-mapping">mapping</a>, <a href="#assemble_crate-readme_file">readme_file</a>, <a href="#assemble_crate-repository">repository</a>, <a href="#assemble_crate-target">target</a>, <a href="#assemble_crate-version_file">version_file</a>)
 </pre>
 
 
@@ -19,12 +19,12 @@ assemble_crate(<a href="#assemble_crate-name">name</a>, <a href="#assemble_crate
 | <a id="assemble_crate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="assemble_crate-authors"></a>authors |  Project authors   | List of strings | optional | [] |
 | <a id="assemble_crate-categories"></a>categories |  Project categories   | List of strings | optional | [] |
-| <a id="assemble_crate-deps"></a>deps |  Maps external Crate dependency to its version   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="assemble_crate-description"></a>description |  The description is a short blurb about the package. crates.io will display this with your package. This should be plain text (not Markdown).             https://doc.rust-lang.org/cargo/reference/manifest.html#the-description-field   | String | required |  |
 | <a id="assemble_crate-documentation"></a>documentation |  Link to documentation of the project   | String | optional | "" |
 | <a id="assemble_crate-homepage"></a>homepage |  Link to homepage of the project   | String | required |  |
 | <a id="assemble_crate-keywords"></a>keywords |  The keywords field is an array of strings that describe this package.             This can help when searching for the package on a registry, and you may choose any words that would help someone find this crate.<br><br>            Note: crates.io has a maximum of 5 keywords.             Each keyword must be ASCII text, start with a letter, and only contain letters, numbers, _ or -, and have at most 20 characters.<br><br>            https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field   | List of strings | optional | [] |
 | <a id="assemble_crate-license"></a>license |  The license field contains the name of the software license that the package is released under.             https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields   | String | required |  |
+| <a id="assemble_crate-mapping"></a>mapping |  Maps Bazel target name to a real crate name, for example:             { "antlr_rust": "antlr-rust" }   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="assemble_crate-readme_file"></a>readme_file |  README of the project   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="assemble_crate-repository"></a>repository |  Repository of the project   | String | required |  |
 | <a id="assemble_crate-target"></a>target |  <code>rust_library</code> label to be included in the package   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -56,9 +56,9 @@ def validate_keywords(keywords):
 
 def _assemble_crate_impl(ctx):
     deps = {}
-    for dependency in ctx.attr.target[RustInfo].deps:
-        name = ctx.attr.mapping.get(dependency[RustInfo].name, dependency[RustInfo].name)
-        deps[name] = dependency[RustInfo].version
+    for dependency in ctx.attr.target[RustLibInfo].deps:
+        name = ctx.attr.mapping.get(dependency[RustLibInfo].name, dependency[RustLibInfo].name)
+        deps[name] = dependency[RustLibInfo].version
     validate_as_url('homepage', ctx.attr.homepage)
     validate_as_url('repository', ctx.attr.repository)
     validate_keywords(ctx.attr.keywords)
@@ -102,7 +102,7 @@ def _assemble_crate_impl(ctx):
         ),
     ]
 
-RustInfo = provider(
+RustLibInfo = provider(
     fields = {
         "name": "Crate name",
         "version": "Crate version",
@@ -111,7 +111,7 @@ RustInfo = provider(
 )
 
 def _aggregate_dependency_info_impl(target, ctx):
-    return RustInfo(
+    return RustLibInfo(
         name = ctx.rule.attr.name,
         version = ctx.rule.attr.version,
         deps = [target for target in getattr(ctx.rule.attr, "deps", [])]
@@ -124,7 +124,7 @@ aggregate_dependency_info = aspect(
     ],
     doc = "Collects the Crate coordinates of the given rust_library and its direct dependencies",
     implementation = _aggregate_dependency_info_impl,
-    provides = [RustInfo],
+    provides = [RustLibInfo],
 )
 
 assemble_crate = rule(

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -68,7 +68,7 @@ def _assemble_crate_impl(ctx):
         "--output-metadata-json", ctx.outputs.metadata_json.path,
         "--root", ctx.attr.target[CrateInfo].root.path,
         "--edition", ctx.attr.target[CrateInfo].edition,
-        "--name", ctx.attr.target[CrateInfo].name,
+        "--name", ctx.attr.target[CrateInformation].name,
         "--version-file", version_file.path,
         "--authors", ";".join(ctx.attr.authors),
         "--keywords", ";".join(ctx.attr.keywords),

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -59,7 +59,6 @@ def _assemble_crate_impl(ctx):
     for dependency in ctx.attr.target[RustInfo].deps:
         name = ctx.attr.mapping.get(dependency[RustInfo].name, dependency[RustInfo].name)
         deps[name] = dependency[RustInfo].version
-    print(deps)
     validate_as_url('homepage', ctx.attr.homepage)
     validate_as_url('repository', ctx.attr.repository)
     validate_keywords(ctx.attr.keywords)

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -109,7 +109,7 @@ CrateSummary = provider(
     },
 )
 
-def _aggregate_crate_information_impl(target, ctx):
+def _aggregate_crate_summary_impl(target, ctx):
     name = ctx.rule.attr.name
     for tag in ctx.rule.attr.tags:
         if tag.startswith("crate-name"):
@@ -121,12 +121,12 @@ def _aggregate_crate_information_impl(target, ctx):
     )
 
 
-aggregate_crate_information = aspect(
+aggregate_crate_summary = aspect(
     attr_aspects = [
        "deps",
     ],
     doc = "Collects the Crate coordinates of the given rust_library and its direct dependencies",
-    implementation = _aggregate_crate_information_impl,
+    implementation = _aggregate_crate_summary_impl,
     provides = [CrateSummary],
 )
 
@@ -136,7 +136,7 @@ assemble_crate = rule(
         "target": attr.label(
             mandatory = True,
             doc = "`rust_library` label to be included in the package",
-            aspects = [aggregate_crate_information],
+            aspects = [aggregate_crate_summary],
             providers = [CrateInfo, CrateSummary],
         ),
         "version_file": attr.label(

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -56,9 +56,9 @@ def validate_keywords(keywords):
 
 def _assemble_crate_impl(ctx):
     deps = {}
-    for dependency in ctx.attr.target[RustLibInfo].deps:
-        name = ctx.attr.mapping.get(dependency[RustLibInfo].name, dependency[RustLibInfo].name)
-        deps[name] = dependency[RustLibInfo].version
+    for dependency in ctx.attr.target[CrateInformation].deps:
+        name = ctx.attr.mapping.get(dependency[CrateInformation].name, dependency[CrateInformation].name)
+        deps[name] = dependency[CrateInformation].version
     validate_as_url('homepage', ctx.attr.homepage)
     validate_as_url('repository', ctx.attr.repository)
     validate_keywords(ctx.attr.keywords)
@@ -102,7 +102,7 @@ def _assemble_crate_impl(ctx):
         ),
     ]
 
-RustLibInfo = provider(
+CrateInformation = provider(
     fields = {
         "name": "Crate name",
         "version": "Crate version",
@@ -110,21 +110,21 @@ RustLibInfo = provider(
     },
 )
 
-def _aggregate_dependency_info_impl(target, ctx):
-    return RustLibInfo(
+def _aggregate_crate_information_impl(target, ctx):
+    return CrateInformation(
         name = ctx.rule.attr.name,
         version = ctx.rule.attr.version,
         deps = [target for target in getattr(ctx.rule.attr, "deps", [])]
     )
 
 
-aggregate_dependency_info = aspect(
+aggregate_crate_information = aspect(
     attr_aspects = [
        "deps",
     ],
     doc = "Collects the Crate coordinates of the given rust_library and its direct dependencies",
-    implementation = _aggregate_dependency_info_impl,
-    provides = [RustLibInfo],
+    implementation = _aggregate_crate_information_impl,
+    provides = [CrateInformation],
 )
 
 assemble_crate = rule(
@@ -133,7 +133,7 @@ assemble_crate = rule(
         "target": attr.label(
             mandatory = True,
             doc = "`rust_library` label to be included in the package",
-            aspects = [aggregate_dependency_info]
+            aspects = [aggregate_crate_information]
         ),
         "version_file": attr.label(
             allow_single_file = True,

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -39,7 +39,7 @@ def _generate_version_file(ctx):
         )
     return version_file
 
-def validate_as_url(field_name, field_value):
+def validate_url(field_name, field_value):
     if not field_value.startswith("http://") and not field_value.startswith("https://"):
         fail("URL for field `{}` must begin with http:// or https://".format(field_name))
 
@@ -58,8 +58,8 @@ def _assemble_crate_impl(ctx):
     deps = {}
     for dependency in ctx.attr.target[CrateSummary].deps:
         deps[dependency[CrateSummary].name] = dependency[CrateSummary].version
-    validate_as_url('homepage', ctx.attr.homepage)
-    validate_as_url('repository', ctx.attr.repository)
+    validate_url('homepage', ctx.attr.homepage)
+    validate_url('repository', ctx.attr.repository)
     validate_keywords(ctx.attr.keywords)
     version_file = _generate_version_file(ctx)
     args = [
@@ -80,7 +80,7 @@ def _assemble_crate_impl(ctx):
         "--deps", ";".join(["{}={}".format(k, v) for k, v in deps.items()]),
     ]
     if ctx.attr.documentation != "":
-        validate_as_url('documentation', ctx.attr.documentation)
+        validate_url('documentation', ctx.attr.documentation)
         args.append("--documentation")
         args.append(ctx.attr.documentation)
     inputs = [version_file]


### PR DESCRIPTION
## What is the goal of this PR?

Allow user to not have to specify duplicate information about the dependencies of the crate package being deployed and instead gather all the info automatically from Bazel.

## What are the changes implemented in this PR?

Fix #323 