### PR TITLE
Platform JVM assembler fixes

### DIFF
--- a/platform/jvm/BUILD
+++ b/platform/jvm/BUILD
@@ -46,3 +46,10 @@ java_binary(
     main_class = "com.vaticle.bazel.distribution.platform.jvm.MainKt",
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "apple-code-sign",
+    define_values = {
+        "APPLE_CODE_SIGN": "yes"
+    }
+)

--- a/platform/jvm/JVMPlatformAssembler.kt
+++ b/platform/jvm/JVMPlatformAssembler.kt
@@ -33,6 +33,7 @@ import com.vaticle.bazel.distribution.platform.jvm.Logging.Logger
 import com.vaticle.bazel.distribution.platform.jvm.Shell.Programs.JAR
 import com.vaticle.bazel.distribution.platform.jvm.Shell.Programs.JPACKAGE
 import com.vaticle.bazel.distribution.platform.jvm.Shell.Programs.JPACKAGE_EXE
+import com.vaticle.bazel.distribution.platform.jvm.Shell.Programs.TAR
 import java.io.File
 import java.lang.System.getenv
 import java.nio.file.Files
@@ -92,7 +93,10 @@ object JVMPlatformAssembler {
 
         fun extractJDK() {
             createDirectory(Path.of(JDK))
-            shell.execute(command = listOf(JAR, "xf", Path.of("..", options.jdkPath).toString()), baseDir = Path.of(JDK))
+            when (currentOS) {
+                MAC, LINUX -> shell.execute(listOf(TAR, "-xf", options.jdkPath, "-C", JDK))
+                WINDOWS -> shell.execute(command = listOf(JAR, "xf", Path.of("..", options.jdkPath).toString()), baseDir = Path.of(JDK))
+            }
         }
 
         fun extractWiXToolset() {

--- a/platform/jvm/Shell.kt
+++ b/platform/jvm/Shell.kt
@@ -62,6 +62,7 @@ class Shell(private val verbose: Boolean = false, private val printSensitiveData
         const val JPACKAGE = "jpackage"
         const val JPACKAGE_EXE = "jpackage.exe"
         const val SECURITY = "security"
+        const val TAR = "tar"
         const val XCRUN = "xcrun"
     }
 

--- a/platform/jvm/rules.bzl
+++ b/platform/jvm/rules.bzl
@@ -172,7 +172,7 @@ windowsWiXToolsetPath: {}
     )
 
     config_path_arg = "--config_path={}".format(config_file.path)
-    if "APPLE_CODE_SIGN" in ctx.var and ctx.var["APPLE_CODE_SIGN"].lower() in "yes, true":
+    if "APPLE_CODE_SIGN" in ctx.var and ctx.var["APPLE_CODE_SIGN"] == "yes":
         _require_apple_code_signing_var(ctx, "APPLE_ID")
         _require_apple_code_signing_var(ctx, "APPLE_ID_PASSWORD")
         _require_apple_code_signing_var(ctx, "APPLE_CODE_SIGNING_CERT_PASSWORD")


### PR DESCRIPTION
## What is the goal of this PR?

The `assemble_jvm_platform` rule was failing to compile due to some broken changes that went in, so we fixed them.

## What are the changes implemented in this PR?

- Undelete config_setting: apple-code-sign (I thought it was unused but it is actually used in typedb-studio)
- Correctly unpackage the JDK on Mac/Linux using `tar`, not `jar`