### PR TITLE
Add maven_artifacts without versions

### DIFF
--- a/maven/deps.bzl
+++ b/maven/deps.bzl
@@ -16,12 +16,22 @@
 # under the License.
 #
 
+maven_artifacts = [
+    "com.eclipsesource.minimal-json:minimal-json",
+    "com.electronwill.night-config:core",
+    "com.electronwill.night-config:toml",
+    "com.google.http-client:google-http-client",
+    "info.picocli:picocli",
+    "org.apache.commons:commons-compress",
+    "org.zeroturnaround:zt-exec",
+]
+
 maven_artifacts_with_versions = [
     "com.eclipsesource.minimal-json:minimal-json:0.9.5",
     "com.electronwill.night-config:core:3.6.5",
     "com.electronwill.night-config:toml:3.6.5",
     "com.google.http-client:google-http-client:1.34.2",
     "info.picocli:picocli:4.3.2",
-    "org.zeroturnaround:zt-exec:1.10",
     "org.apache.commons:commons-compress:1.21",
+    "org.zeroturnaround:zt-exec:1.10",
 ]


### PR DESCRIPTION
## What is the goal of this PR?

We had previously deleted maven_artifacts (without versions) because of an incorrect assumption that they were unused - we are now bringing them back (they are used when setting up external repositories to depend on Maven packages via Bazel)

## What are the changes implemented in this PR?

- Add maven_artifacts without versions