### PR TITLE
Pass registry URL in correct format in deploy_npm

### DIFF
--- a/npm/deploy/Deployer.kt
+++ b/npm/deploy/Deployer.kt
@@ -39,8 +39,18 @@ class Deployer(private val options: Options) {
     }
 
     private fun configureAuthToken() {
-        val partialRegistryURL = options.registryURL.split(":")[1].trimEnd('/') // e.g: https://registry.npmjs.org/ --> //registry.npmjs.org
-        Files.writeString(Path.of(".npmrc"), "$partialRegistryURL/:_authToken=${options.npmToken}")
+        Files.writeString(Path.of(".npmrc"), "${npmrcFormattedURL(options.registryURL)}/:_authToken=${options.npmToken}")
+    }
+
+    /**
+     * Convert a registry URL to the format expected by .npmrc.
+     *
+     * ### Examples:
+     * - https://registry.npmjs.org/ --> //registry.npmjs.org
+     * - registry.npmjs.org --> //registry.npmjs.org
+     */
+    private fun npmrcFormattedURL(url: String): String {
+        return url.trimEnd('/').let { if (":" in it) it.split(":")[1] else "//$it" }
     }
 
     private fun publishPackage() {

--- a/npm/deploy/Deployer.kt
+++ b/npm/deploy/Deployer.kt
@@ -39,7 +39,8 @@ class Deployer(private val options: Options) {
     }
 
     private fun configureAuthToken() {
-        Files.writeString(Path.of(".npmrc"), "//${options.registryURL}:_authToken=${options.npmToken}")
+        val partialRegistryURL = options.registryURL.split(":")[1].trimEnd('/') // e.g: https://registry.npmjs.org/ --> //registry.npmjs.org
+        Files.writeString(Path.of(".npmrc"), "$partialRegistryURL/:_authToken=${options.npmToken}")
     }
 
     private fun publishPackage() {


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a bug where `deploy_npm` would fail to authenticate because it was passing the registry URL in an incorrect format to the `.npmrc` file.

## What are the changes implemented in this PR?

Pass registry URL in correct format in deploy_npm