### PR TITLE
Better support for multiplatform Maven publications w/ local JARs

### DIFF
--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -58,6 +58,9 @@ class JarAssembler : Callable<Unit> {
     @Option(names = ["--jars"], split = ";")
     lateinit var jars: Array<File>
 
+    @Option(names = ["--fail_on_duplicate_entry"])
+    lateinit var failOnDuplicateEntry: Boolean
+
     private val entries = HashMap<String, ByteArray>()
     private val entryNames = mutableSetOf<String>()
 
@@ -72,7 +75,9 @@ class JarAssembler : Callable<Unit> {
                 ZipFile(jar).use { jarZip ->
                     jarZip.entries().asSequence().forEach { entry ->
                         if (entryNames.contains(entry.name)) {
-                            throw RuntimeException("duplicate entry in the JAR: ${entry.name}")
+                            if (failOnDuplicateEntry)
+                                throw RuntimeException("duplicate entry in the JAR: ${entry.name}")
+                            return@forEach
                         }
                         if (entry.name.contains("META-INF")) {
                             // pom.xml will be added by us

--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -59,7 +59,7 @@ class JarAssembler : Callable<Unit> {
     lateinit var jars: Array<File>
 
     @Option(names = ["--fail_on_duplicate_entry"])
-    lateinit var failOnDuplicateEntry: Boolean
+    var failOnDuplicateEntry: Boolean = True
 
     private val entries = HashMap<String, ByteArray>()
     private val entryNames = mutableSetOf<String>()

--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -58,9 +58,6 @@ class JarAssembler : Callable<Unit> {
     @Option(names = ["--jars"], split = ";")
     lateinit var jars: Array<File>
 
-    @Option(names = ["--fail_on_duplicate_entry"])
-    var failOnDuplicateEntry: Boolean = true
-
     private val entries = HashMap<String, ByteArray>()
     private val entryNames = mutableSetOf<String>()
 
@@ -75,9 +72,7 @@ class JarAssembler : Callable<Unit> {
                 ZipFile(jar).use { jarZip ->
                     jarZip.entries().asSequence().forEach { entry ->
                         if (entryNames.contains(entry.name)) {
-                            if (failOnDuplicateEntry)
-                                throw RuntimeException("duplicate entry in the JAR: ${entry.name}")
-                            return@forEach
+                            throw RuntimeException("duplicate entry in the JAR: ${entry.name}")
                         }
                         if (entry.name.contains("META-INF")) {
                             // pom.xml will be added by us

--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -59,7 +59,7 @@ class JarAssembler : Callable<Unit> {
     lateinit var jars: Array<File>
 
     @Option(names = ["--fail_on_duplicate_entry"])
-    var failOnDuplicateEntry: Boolean = True
+    var failOnDuplicateEntry: Boolean = true
 
     private val entries = HashMap<String, ByteArray>()
     private val entryNames = mutableSetOf<String>()

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -205,7 +205,7 @@ def _aggregate_dependency_info_impl(target, ctx):
 
     return JarInfo(
         name = maven_coordinates,
-        deps = depset([dependency], transitive = [target[JarInfo].deps for target in deps_all]),
+        deps = depset([dependency] if dependency else [], transitive = [target[JarInfo].deps for target in deps_all]),
     )
 
 aggregate_dependency_info = aspect(

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -196,11 +196,12 @@ def _aggregate_dependency_info_impl(target, ctx):
             maven_coordinates = maven_coordinates
         )
     elif target[OutputGroupInfo].compilation_outputs:
+        source_jars = target[OutputGroupInfo]._source_jars.to_list()
         # include in the JAR
         dependency = struct(
             type = "jar",
             class_jar = target[OutputGroupInfo].compilation_outputs.to_list()[0],
-            source_jar = target[OutputGroupInfo]._source_jars.to_list()[-1],
+            source_jar = source_jars[-1] if source_jars else None,
         )
 
     return JarInfo(

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -210,12 +210,11 @@ def _aggregate_dependency_info_impl(target, ctx):
     elif target[JavaInfo].runtime_output_jars:
         jars = target[JavaInfo].runtime_output_jars
         source_jars = target[JavaInfo].source_jars
-        create_dependency = lambda jar, source_jar: struct(
+        dependencies = [struct(
             type = "jar",
             class_jar = jar,
             source_jar = source_jar,
-        )
-        dependencies = [create_dependency(dep) for dep in zip(
+        ) for (jar, source_jar) in zip(
             jars, source_jars + [None] * (len(jars) - len(source_jars))
         )]
 

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -218,13 +218,9 @@ def _aggregate_dependency_info_impl(target, ctx):
             jars, source_jars + [None] * (len(jars) - len(source_jars))
         )]
 
-    print([target[JarInfo] for target in deps_all])
-    print("hey")
-    print([target[JarInfo].deps for target in deps_all])
-
     return JarInfo(
         name = maven_coordinates,
-        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all]),
+        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all if target[JarInfo].type == "pom"]),
     )
 
 aggregate_dependency_info = aspect(

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -195,7 +195,7 @@ def _aggregate_dependency_info_impl(target, ctx):
             type = "pom",
             maven_coordinates = maven_coordinates
         )
-    else:
+    else if target[OutputGroupInfo].compilation_outputs:
         # include in the JAR
         dependency = struct(
             type = "jar",

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -220,7 +220,7 @@ def _aggregate_dependency_info_impl(target, ctx):
 
     return JarInfo(
         name = maven_coordinates,
-        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all]),
+        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all if target[OutputGroupInfo].compilation_outputs]),
     )
 
 aggregate_dependency_info = aspect(

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -195,7 +195,7 @@ def _aggregate_dependency_info_impl(target, ctx):
             type = "pom",
             maven_coordinates = maven_coordinates
         )
-    else if target[OutputGroupInfo].compilation_outputs:
+    elif target[OutputGroupInfo].compilation_outputs:
         # include in the JAR
         dependency = struct(
             type = "jar",

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -297,7 +297,7 @@ MavenDeploymentInfo = provider(
 
 
 def _deploy_maven_impl(ctx):
-    deploy_maven_script = ctx.actions.declare_file("deploy.py")
+    deploy_maven_script = ctx.actions.declare_file("%s-deploy.py" % ctx.attr.name)
 
     lib_jar_link = "lib.jar"
     src_jar_link = "lib.srcjar"

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -220,7 +220,7 @@ def _aggregate_dependency_info_impl(target, ctx):
 
     return JarInfo(
         name = maven_coordinates,
-        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all if target[JarInfo].type == "pom"]),
+        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all if target[JarInfo].name]),
     )
 
 aggregate_dependency_info = aspect(

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -186,7 +186,7 @@ def _aggregate_dependency_info_impl(target, ctx):
     deps = getattr(ctx.rule.attr, "deps", [])
     runtime_deps = getattr(ctx.rule.attr, "runtime_deps", [])
     exports = getattr(ctx.rule.attr, "exports", [])
-    deps_all = map(lambda target: target[JarInfo], deps + exports + runtime_deps)
+    deps_all = deps + exports + runtime_deps
 
     maven_coordinates = find_maven_coordinates(target, tags)
     dependencies = []
@@ -224,8 +224,8 @@ def _aggregate_dependency_info_impl(target, ctx):
             # Filter transitive JARs from dependency that has maven coordinates
             # because those dependencies will already include the JARs as part
             # of their classpath
-            depset([dep for dep in target.deps.to_list() if dep.type == 'pom'])
-                if target.name else target.deps for target in deps_all
+            depset([dep for dep in target[JarInfo].deps.to_list() if dep.type == 'pom'])
+                if target[JarInfo].name else target[JarInfo].deps for target in deps_all
         ]),
     )
 

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -218,8 +218,23 @@ def _aggregate_dependency_info_impl(target, ctx):
             jars, source_jars + [None] * (len(jars) - len(source_jars))
         )]
 
+    print("1")
+    print([target for target in deps_all])
+    print("2")
+    print([target[JarInfo] for target in deps_all])
+    print("3")
+    print([target[JarInfo].deps for target in deps_all])
+    print("4")
+    print([target for target in deps_all if target[JarInfo].name])
+    print("5")
+    print([target[JarInfo] for target in deps_all if target[JarInfo].name])
+    print("6")
+    print([target[JarInfo].deps for target in deps_all if target[JarInfo].name])
+    print("end")
+
     return JarInfo(
         name = maven_coordinates,
+        # Not entirely sure why this doesn't work.... trying to exclude transitive deps that don't have a maven coordinate
         deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all if target[JarInfo].name]),
     )
 

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -108,7 +108,7 @@ def _generate_class_jar(ctx, pom_file):
             "--pom-file=" + pom_file.path,
             "--jars=" + ";".join(class_jar_paths),
             "--output=" + output_jar.path,
-            "--fail_on_duplicate_entry=" + ctx.attr.fail_on_duplicate_entry,
+            "--fail_on_duplicate_entry=" + str(ctx.attr.fail_on_duplicate_entry),
         ],
     )
 
@@ -143,7 +143,7 @@ def _generate_source_jar(ctx):
         arguments = [
             "--jars=" + ";".join(source_jar_paths),
             "--output=" + output_jar.path,
-            "--fail_on_duplicate_entry=" + ctx.attr.fail_on_duplicate_entry,
+            "--fail_on_duplicate_entry=" + str(ctx.attr.fail_on_duplicate_entry),
         ],
     )
 

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -108,7 +108,6 @@ def _generate_class_jar(ctx, pom_file):
             "--pom-file=" + pom_file.path,
             "--jars=" + ";".join(class_jar_paths),
             "--output=" + output_jar.path,
-            "--fail_on_duplicate_entry=" + str(ctx.attr.fail_on_duplicate_entry),
         ],
     )
 
@@ -143,7 +142,6 @@ def _generate_source_jar(ctx):
         arguments = [
             "--jars=" + ";".join(source_jar_paths),
             "--output=" + output_jar.path,
-            "--fail_on_duplicate_entry=" + str(ctx.attr.fail_on_duplicate_entry),
         ],
     )
 
@@ -286,10 +284,6 @@ assemble_maven = rule(
         "scm_url": attr.string(
             default = "PROJECT_URL",
             doc = "Project source control URL to fill into pom.xml",
-        ),
-        "fail_on_duplicate_entry": attr.bool(
-            default = True,
-            doc = "Fail if detected duplicate entries when assembling the JAR",
         ),
         "_pom_generator": attr.label(
             default = "@vaticle_bazel_distribution//maven:pom-generator",

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -206,6 +206,8 @@ def _aggregate_dependency_info_impl(target, ctx):
         ) for (jar, source_jar) in zip(
             jars, source_jars + [None] * (len(jars) - len(source_jars))
         )]
+    else:
+        fail("Unsure how to package dependency for target: %s" % target)
 
     return JarInfo(
         name = maven_coordinates,

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -195,15 +195,6 @@ def _aggregate_dependency_info_impl(target, ctx):
             type = "pom",
             maven_coordinates = maven_coordinates
         )]
-    # include generic compilation_outputs in JAR
-    elif target[OutputGroupInfo].compilation_outputs:
-        source_jars = target[OutputGroupInfo]._source_jars.to_list()
-        # include in the JAR
-        dependencies = [struct(
-            type = "jar",
-            class_jar = target[OutputGroupInfo].compilation_outputs.to_list()[0],
-            source_jar = source_jars[-1] if source_jars else None,
-        )]
     # include runtime output jars
     elif target[JavaInfo].runtime_output_jars:
         jars = target[JavaInfo].runtime_output_jars

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -218,9 +218,13 @@ def _aggregate_dependency_info_impl(target, ctx):
             jars, source_jars + [None] * (len(jars) - len(source_jars))
         )]
 
+    print([target[JarInfo] for target in deps_all])
+    print("hey")
+    print([target[JarInfo].deps for target in deps_all])
+
     return JarInfo(
         name = maven_coordinates,
-        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all if target[OutputGroupInfo].compilation_outputs]),
+        deps = depset(dependencies, transitive = [target[JarInfo].deps for target in deps_all]),
     )
 
 aggregate_dependency_info = aspect(


### PR DESCRIPTION
## What is the goal of this PR?

Support bundling local `java_import` deps that may or may not conflict when bundled (#335).

The use case here is around bundling JARs for different platforms and potentially having a multiplatform JAR as well. 

## What are the changes implemented in this PR?

1. Support for bundling `java_import` targets

Add a bit more graceful handling for dependencies that don't have a `maven_coordinates` tag. Originally, the aggregation would attempt to just pull directly from `target[OutputGroupInfo].compilation_outputs` without checking to see if it actually existed, resulting in the error from #335. Now, that logic is guarded in checking that `compilation_outputs` is truthy. Additionally, the source JAR is optional in `java_import`, so I added some safety against adding the source JAR when it doesn't exist.

Just that alone didn't fix `java_import` targets though, as `java_import` doesn't treat the input JAR as `compilation_outputs`. Locally, I had wrapped the `java_import` rule to copy over `target[JavaInfo].runtime_output_jars` into `target[OutputGroupInfo].compilation_outputs`, but requiring consumers to have to do that isn't great. So, I added another branch to the aggregation method, that checks for `target[JavaInfo].runtime_output_jars` and will create a collection of dependencies if truthy. Because `java_import` can accept multiple JARs, we need to ensure that a dependency struct for each will be created, potentially mapping to a source jar, if also defined for the index.

There are technically two different fields from `JavaInfo` that would've worked for `java_import`:
[runtime_output_jars](https://bazel.build/rules/lib/JavaInfo?hl=en#runtime_output_jars)
[full_compile_jars](https://bazel.build/rules/lib/JavaInfo?hl=en#full_compile_jars)

I used `runtime_output_jars` only because that made a _little_ more sense to me? To bundle the runtime JAR vs the compile JAR. I'm not really sure, but there is no difference between the two for `java_import`s. Open to input here.

<details>
<summary>Provider info for a `java_import` target</summary>

```
    "JavaInfo": struct(
        annotation_processing = None,
        api_generating_plugins = <unknown object com.google.devtools.build.lib.rules.java.AutoValue_JavaPluginInfo_JavaPluginData>,
        compilation_info = <unknown object com.google.devtools.build.lib.rules.java.JavaCompilationInfoProvider>,
        compile_jars = depset([
            <generated file j2v8/libs/_ijar/j2v8_empty/j2v8/libs/j2v8_empty-6.1.0-ijar.jar>,
            <generated file j2v8/libs/_ijar/j2v8_empty/j2v8/libs/j2v8_macos_x86_64-6.1.0-ijar.jar>
        ], order = "preorder"),
        full_compile_jars = depset([
            <source file j2v8/libs/j2v8_empty-6.1.0.jar>,
            <source file j2v8/libs/j2v8_macos_x86_64-6.1.0.jar>
        ], order = "preorder"),
        java_outputs = [
            <unknown object com.google.devtools.build.lib.rules.java.AutoValue_JavaRuleOutputJarsProvider_JavaOutput>,
            <unknown object com.google.devtools.build.lib.rules.java.AutoValue_JavaRuleOutputJarsProvider_JavaOutput>
        ],
        outputs = <unknown object com.google.devtools.build.lib.rules.java.JavaRuleOutputJarsProvider>,
        plugins = <unknown object com.google.devtools.build.lib.rules.java.AutoValue_JavaPluginInfo_JavaPluginData>,
        runtime_output_jars = [
            <source file j2v8/libs/j2v8_empty-6.1.0.jar>,
            <source file j2v8/libs/j2v8_macos_x86_64-6.1.0.jar>
        ],
        source_jars = [<source file j2v8/libs/srcs.jar>],
        transitive_compile_time_jars = depset([
            <generated file j2v8/libs/_ijar/j2v8_empty/j2v8/libs/j2v8_empty-6.1.0-ijar.jar>,
            <generated file j2v8/libs/_ijar/j2v8_empty/j2v8/libs/j2v8_macos_x86_64-6.1.0-ijar.jar>
        ], order = "preorder"),
        transitive_deps = depset([
            <generated file j2v8/libs/_ijar/j2v8_empty/j2v8/libs/j2v8_empty-6.1.0-ijar.jar>,
            <generated file j2v8/libs/_ijar/j2v8_empty/j2v8/libs/j2v8_macos_x86_64-6.1.0-ijar.jar>
        ], order = "preorder"),
        transitive_native_libraries = depset([], order = "topological"),
        transitive_runtime_deps = depset([
            <source file j2v8/libs/j2v8_empty-6.1.0.jar>,
            <source file j2v8/libs/j2v8_macos_x86_64-6.1.0.jar>
        ], order = "preorder"),
        transitive_runtime_jars = depset([
            <source file j2v8/libs/j2v8_empty-6.1.0.jar>,
            <source file j2v8/libs/j2v8_macos_x86_64-6.1.0.jar>
        ], order = "preorder"),
        transitive_source_jars = depset([<source file j2v8/libs/srcs.jar>])
    ),
    "OutputGroupInfo": struct(
        _direct_source_jars = depset([<source file j2v8/libs/srcs.jar>]),
        _hidden_top_level_INTERNAL_ = depset([<source file j2v8/libs/j2v8_empty-6.1.0.jar>, <source file j2v8/libs/j2v8_macos_x86_64-6.1.0.jar>]),
        _source_jars = depset([<source file j2v8/libs/srcs.jar>]),
        compilation_outputs = depset([])
    )
```
</details>

Finally, the last thing required for local JARs was ensuring that multiple targets aren't bundling the local JAR multiple times. The strategy here was to filter out transitive JAR dependencies from dependencies that have Maven coordinates, since the local JAR would have already been bundled within that dependency and can be pulled in from a Maven repository.

https://github.com/sugarmanz/bazel-distribution/blob/412162f901f6650e67e014156945ee06c6619b1b/maven/rules.bzl#L223-L229

2. ~~Add flag for allowing conflicts during JAR assembly~~

~~In the use case above, I mentioned publishing platform specific JARs, of which each bundle their own copy of a platform specific local JAR that includes the classes and platform binary for that lib. I also need to publish an "uber" JAR that contains all the binaries for each platform. When attempting to assemble the JAR for this, the JAR assembler would throw an error for duplicate entries. This makes sense for the primary use case, but in this case, I know that the classes are the same and would like to ignore the duplicates, as is currently done when I build my project with Gradle. Thus, I added a flag to not throw when duplicates are detected. This defaults to `True`, ensuring the same behavior unless specifically overridden by the consumer.~~

Shelved because this issue was inherently fixed with:
https://github.com/sugarmanz/bazel-distribution/blob/412162f901f6650e67e014156945ee06c6619b1b/maven/rules.bzl#L223-L229

3. Scope generated `deploy.py`

This essentially enables the `deploy_maven` rule to be used multiple times in the same build file, which is desirable for my mulitplatform project, as I want to have all my deploy targets for that module in the same build file.

Closes #335 
