### PR TITLE
Make assemble_npm support M1 architecture

### DIFF
--- a/npm/assemble/assemble.py
+++ b/npm/assemble/assemble.py
@@ -72,6 +72,7 @@ subprocess.check_call([
         '/bin/',
         os.path.realpath('external/nodejs/bin/nodejs/bin/'),
         os.path.realpath('external/nodejs_darwin_amd64/bin/'),
+        os.path.realpath('external/nodejs_darwin_arm64/bin/'),
         os.path.realpath('external/nodejs_linux_amd64/bin/'),
         os.path.realpath('external/nodejs_windows_amd64/bin/'),
     ])


### PR DESCRIPTION
## What is the goal of this PR?

To fix issues with running the assembly rules with a m1 mac

## What are the changes implemented in this PR?

- Adds the correct architecture folder under the `PATH` search
