### PR TITLE
Android library publishing support

### DIFF
--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -74,6 +74,9 @@ class PomGenerator : Callable<Unit> {
     @Option(names = ["--target_deps_coordinates"])
     lateinit var dependencyCoordinates: String
 
+    @Option(names = ["--packaging"])
+    var packaging = ""
+
     fun getLicenseInfo(license_id: String): Pair<String, String> {
         return when {
             license_id.equals("apache") -> {
@@ -223,6 +226,12 @@ class PomGenerator : Callable<Unit> {
         val versionElem = pom.createElement("version")
         versionElem.appendChild(pom.createTextNode(version))
         rootElement.appendChild(versionElem)
+
+        if (packaging.isNotEmpty() && packaging != "jar") {
+            val packagingElem = pom.createElement("packaging")
+            packagingElem.appendChild(pom.createTextNode(packaging))
+            rootElement.appendChild(packagingElem)
+        }
 
         // add dependency information
         rootElement.appendChild(dependencies(pom, version, workspace_refs))

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -95,6 +95,7 @@ maven_url = maven_repositories[repo_type]
 jar_path = "$JAR_PATH"
 pom_file_path = "$POM_PATH"
 srcjar_path = "$SRCJAR_PATH"
+packaging = "$PACKAGING"
 
 namespace = { 'namespace': 'http://maven.apache.org/POM/4.0.0' }
 root = ElementTree.parse(pom_file_path).getroot()
@@ -127,12 +128,13 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
                      'must have a version which complies to this regex: {}'
                      .format(version, repo_type, version_release_regex))
 
+artifact_extension = '.' + packaging
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
     coordinates=group_id.text.replace('.', '/'), version=version, artifact=artifact_id.text)
 
-upload(maven_url, username, password, jar_path, filename_base + '.jar')
+upload(maven_url, username, password, jar_path, filename_base + artifact_extension)
 if should_sign:
-    upload(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
+    upload(maven_url, username, password, sign(jar_path), filename_base + artifact_extension + '.asc')
 upload(maven_url, username, password, pom_file_path, filename_base + '.pom')
 if should_sign:
     upload(maven_url, username, password, sign(pom_file_path), filename_base + '.pom.asc')
@@ -158,12 +160,12 @@ with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_sha1:
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_md5:
     jar_md5.write(md5(jar_path))
     jar_md5.flush()
-    upload(maven_url, username, password, jar_md5.name, filename_base + '.jar.md5')
+    upload(maven_url, username, password, jar_md5.name, filename_base + artifact_extension + '.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_sha1:
     jar_sha1.write(sha1(jar_path))
     jar_sha1.flush()
-    upload(maven_url, username, password, jar_sha1.name, filename_base + '.jar.sha1')
+    upload(maven_url, username, password, jar_sha1.name, filename_base + artifact_extension + '.sha1')
 
 if os.path.exists(srcjar_path):
     with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_md5:


### PR DESCRIPTION
## What is the goal of this PR?

Add publishing support for `android_library` targets (#233)

## What are the changes implemented in this PR?

First, the rules, assemblers, and scripts need to take into account other packaging types. Determining the packaging type and passing that info along via the providers was the necessary first step.

Second, the `JarAssembler.kt` file only supported packaging a `JAR`. Rather than duplicate the script for `AAR` support, I added support directly in that file to reuse a lot of the same logic used to assemble `JAR`s. There is one TODO left surrounding duplicate entries, but I believe that might be something related to my specific project. 

Third, handling the Android SDK and neverlink dependencies. In order to be able to perform the `aggregate_dependency_info` aspect, the Android SDK target needed to be handled. It is a specific rule type baked into the Bazel codebase. I wasn't really sure how to determine the rule type within the aspect, so I just hardcoded the label as something to ignore (gross, I know). Additionally, a third party ruleset I use for databinding support had an additional `java_library` that captured the Android SDK. Luckily, this was marked as `neverlink`, so I was able to key off of that attribute to avoid capturing the Android SDK from that target in the transitive closure. That should be a decent strategy to follow since the artifacts we're assembling probably shouldn't include `neverlink` dependencies that were just used to compile.
