### PR TITLE
Bump copyright year to 2022

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Vaticle Bazel Distribution
-Copyright (C) 2021 Vaticle
+Copyright (C) 2022 Vaticle
 
 This product includes software developed at Vaticle (http://vaticle.com/)

--- a/common/Logging.kt
+++ b/common/Logging.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/common/assemble_versioned/BUILD
+++ b/common/assemble_versioned/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/checksum/BUILD
+++ b/common/checksum/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/generate_json_config/BUILD
+++ b/common/generate_json_config/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/java_deps/BUILD
+++ b/common/java_deps/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/targz/BUILD
+++ b/common/targz/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/tgz2zip/BUILD
+++ b/common/tgz2zip/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/util/FileUtil.kt
+++ b/common/util/FileUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/common/util/PropertiesUtil.kt
+++ b/common/util/PropertiesUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/common/util/SystemUtil.kt
+++ b/common/util/SystemUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/common/workspace_refs/BUILD
+++ b/common/workspace_refs/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/zip/BUILD
+++ b/common/zip/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/crates/CrateAssembler.kt
+++ b/crates/CrateAssembler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/crates/CrateDeployer.kt
+++ b/crates/CrateDeployer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/maven/JarAssembler.kt
+++ b/maven/JarAssembler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/npm/deploy/DeployNPM.kt
+++ b/npm/deploy/DeployNPM.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/npm/deploy/Deployer.kt
+++ b/npm/deploy/Deployer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/platform/jvm/Main.kt
+++ b/platform/jvm/Main.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/platform/jvm/Options.kt
+++ b/platform/jvm/Options.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
## What is the goal of this PR?

We update the copyright header year to 2022.

## What are the changes implemented in this PR?

Replace the year 2021 with 2022 in each copyright header.