### PR TITLE
[assemble-pip] Add python_requires to limit package to python 3 only

### DIFF
--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -57,22 +57,23 @@ args.imports = list(map(
 # new package root
 pkg_dir = tempfile.mkdtemp()
 
+if not args.files:
+    raise Exception("Cannot create an archive without any files")
 
-if args.files:
-    for f in args.files:
-        fn = f
-        for _imp in args.imports:
-            match = _imp.match(fn)
-            if match:
-                fn = match.group('fn')
-                break
-        try:
-            e = os.path.join(pkg_dir, os.path.dirname(fn))
-            os.makedirs(e)
-        except OSError:
-            # directory already exists
-            pass
-        shutil.copy(f, os.path.join(pkg_dir, fn))
+for f in args.files:
+    fn = f
+    for _imp in args.imports:
+        match = _imp.match(fn)
+        if match:
+            fn = match.group('fn')
+            break
+    try:
+        e = os.path.join(pkg_dir, os.path.dirname(fn))
+        os.makedirs(e)
+    except OSError:
+        # directory already exists
+        pass
+    shutil.copy(f, os.path.join(pkg_dir, fn))
 
 setup_py = os.path.join(pkg_dir, 'setup.py')
 readme = os.path.join(pkg_dir, 'README.md')

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -58,20 +58,21 @@ args.imports = list(map(
 pkg_dir = tempfile.mkdtemp()
 
 
-for f in args.files:
-    fn = f
-    for _imp in args.imports:
-        match = _imp.match(fn)
-        if match:
-            fn = match.group('fn')
-            break
-    try:
-        e = os.path.join(pkg_dir, os.path.dirname(fn))
-        os.makedirs(e)
-    except OSError:
-        # directory already exists
-        pass
-    shutil.copy(f, os.path.join(pkg_dir, fn))
+if args.files:
+    for f in args.files:
+        fn = f
+        for _imp in args.imports:
+            match = _imp.match(fn)
+            if match:
+                fn = match.group('fn')
+                break
+        try:
+            e = os.path.join(pkg_dir, os.path.dirname(fn))
+            os.makedirs(e)
+        except OSError:
+            # directory already exists
+            pass
+        shutil.copy(f, os.path.join(pkg_dir, fn))
 
 setup_py = os.path.join(pkg_dir, 'setup.py')
 readme = os.path.join(pkg_dir, 'README.md')

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -111,7 +111,8 @@ def _assemble_pip_impl(ctx):
           "{author}": ctx.attr.author,
           "{author_email}": ctx.attr.author_email,
           "{license}": ctx.attr.license,
-          "{long_description_file}": ctx.file.long_description_file.path
+          "{long_description_file}": ctx.file.long_description_file.path,
+          "{python_requires}": ctx.attr.python_requires,
       },
     )
 
@@ -261,6 +262,10 @@ assemble_pip = rule(
             allow_single_file = True,
             mandatory = True,
             doc = "A file with the list of required packages for this one",
+        ),
+        "python_requires": attr.string(
+            default = ">0",
+            doc = "If your project only runs on certain Python versions, setting the python_requires argument to the appropriate PEP 440 version specifier string will prevent pip from installing the project on other Python versions.",
         ),
         "_setup_py_template": attr.label(
             allow_single_file = True,

--- a/pip/templates/setup.py
+++ b/pip/templates/setup.py
@@ -37,4 +37,5 @@ setup(
     packages=packages,
     install_requires=INSTALL_REQUIRES_PLACEHOLDER,
     zip_safe=False,
+    python_requires="{python_requires}",
 )


### PR DESCRIPTION
## What is the goal of this PR?

Produce pip distributions that aren't available to python 2 users (or any arbitrary python version)

## What are the changes implemented in this PR?

Adds a `python_requires` attribute to `assemble_pip` passed through to `setup.py` as defined in https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires

For example,
```py
assemble_pip(
    ...
    python_requires = ">=3",
)
```
should produce a setup.py that makes the package unavailable to users of python 2.

Also fixes an error in the assemble script if the package is empty.