### PR TITLE
[assemble-pip] Support stripping a path prefix from package files

### DIFF
--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -43,6 +43,7 @@ parser.add_argument('--requirements_file', help="install_requires")
 parser.add_argument('--readme', help="README file")
 parser.add_argument('--files', nargs='+', help='Python files to pack into archive')
 parser.add_argument('--imports', nargs='+', help='Folders considered to be source code roots')
+parser.add_argument('--strip_prefix', help="Path prefix to strip from all package files")
 
 args = parser.parse_args()
 
@@ -65,13 +66,16 @@ for f in args.files:
         if match:
             fn = match.group('fn')
             break
+    destination_f = fn
     try:
-        e = os.path.join(pkg_dir, os.path.dirname(fn))
+        if args.strip_prefix and destination_f.startswith(args.strip_prefix):
+            destination_f = destination_f[len(args.strip_prefix):]
+        e = os.path.join(pkg_dir, os.path.dirname(destination_f))
         os.makedirs(e)
     except OSError:
         # directory already exists
         pass
-    shutil.copy(f, os.path.join(pkg_dir, fn))
+    shutil.copy(f, os.path.join(pkg_dir, destination_f))
 
 setup_py = os.path.join(pkg_dir, 'setup.py')
 readme = os.path.join(pkg_dir, 'README.md')

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -94,6 +94,9 @@ def _assemble_pip_impl(ctx):
     args.add('--output', ctx.outputs.pip_package.path)
     args.add('--readme', ctx.file.long_description_file.path)
 
+    if ctx.attr.strip_prefix:
+        args.add('--strip_prefix', ctx.attr.strip_prefix)
+
     # Final 'setup.py' is generated in 2 steps
     setup_py = ctx.actions.declare_file("setup.py")
     preprocessed_setup_py = ctx.actions.declare_file("_setup.py")
@@ -261,6 +264,9 @@ assemble_pip = rule(
             allow_single_file = True,
             mandatory = True,
             doc = "A file with the list of required packages for this one",
+        ),
+        "strip_prefix": attr.string(
+            doc = "Path prefix to strip from all package files",
         ),
         "_setup_py_template": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
## What is the goal of this PR?

In a monorepo with many python packages, where each is individually published, the libraries might be a directory or two lower in the repo than what you want to be published.

For example, take this folder structure

```
javacode/
pybindings/
    apiclient/
        BUILD.bazel
        __init__.py
````

All the python packages are under `pybindings`, but I don't want the root folder showing up in the users' imports.

Currently, the assembled file persists the `pybindings/apiclient` structure. I'd like to propose a way to strip `pybindings/` in this case and assemble a file starting at `apiclient`.

## What are the changes implemented in this PR?

Adds `strip_prefix` to `assemble_pip`. When the input files are copied, if there's a `strip_prefix`, and a file starts with that prefix, it is stripped from the start of the path.
