### PR TITLE
[assemble_maven] add developers tag support for pom (to support Maven Central)

### DIFF
--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -72,6 +72,7 @@ def _generate_pom_file(ctx, version_file):
             "--project_url=" + ctx.attr.project_url,
             "--license=" + ctx.attr.license,
             "--scm_url=" + ctx.attr.scm_url,
+            "--developers=" + json.encode(ctx.attr.developers),
             "--target_group_id=" + maven_coordinates.group_id,
             "--target_artifact_id=" + maven_coordinates.artifact_id,
             "--target_deps_coordinates=" + ";".join(pom_deps),
@@ -277,6 +278,10 @@ assemble_maven = rule(
         "scm_url": attr.string(
             default = "PROJECT_URL",
             doc = "Project source control URL to fill into pom.xml",
+        ),
+        "developers": attr.string_list_dict(
+            default = {},
+            doc = "Project developers to fill into pom.xml",
         ),
         "_pom_generator": attr.label(
             default = "@vaticle_bazel_distribution//maven:pom-generator",


### PR DESCRIPTION
## What is the goal of this PR?

Support publishing to Maven Central again. Was originally done in #133, but the `developers` tag was never migrated to the maven rule rewrite in #296.

## What are the changes implemented in this PR?

Add an optional `developers` attribute to `assemble_maven` rule as a `string_list_dict`. Developers can be described as such:

```
developers = {
  "sugarmanz": ["name=Jeremiah Zucker", "email=zucker.jeremiah@gmail.com"],
  "adierkens": ["name=Adam Dierkens"],
}
```

And will be populated as:

```xml
<developers>
  <developer>
    <id>adierkens</id>
    <name>Adam Dierkens</name>
  </developer>
  <developer>
    <id>sugarmanz</id>
    <name>Jeremiah Zucker</name>
    <email>zucker.jeremiah@gmail.com</email>
  </developer>
</developers>
```
