### PR TITLE
[deploy_maven] allow for release repo override via command line

### DIFF
--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+_DEPLOY_MAVEN_RELEASE_REPO_KEY = "DEPLOY_MAVEN_RELEASE_REPO"
 
 def _parse_maven_coordinates(coordinates_string, enforce_version_template=True):
     coordinates = coordinates_string.split(':')
@@ -315,6 +316,10 @@ def _deploy_maven_impl(ctx):
     src_jar_link = "lib.srcjar"
     pom_xml_link = ctx.attr.target[MavenDeploymentInfo].pom.basename
 
+    release_repo = ctx.attr.release
+    if _DEPLOY_MAVEN_RELEASE_REPO_KEY in ctx.var:
+        release_repo = ctx.var[_DEPLOY_MAVEN_RELEASE_REPO_KEY]
+
     ctx.actions.expand_template(
         template = ctx.file._deployment_script,
         output = deploy_maven_script,
@@ -323,7 +328,7 @@ def _deploy_maven_impl(ctx):
             "$SRCJAR_PATH": src_jar_link,
             "$POM_PATH": pom_xml_link,
             "{snapshot}": ctx.attr.snapshot,
-            "{release}": ctx.attr.release
+            "{release}": release_repo,
         }
     )
 


### PR DESCRIPTION
## What is the goal of this PR?

Allow for the release repo to be configured dynamically. With Maven Central, there is the opportunity to batch a release with a singular staging repository. Unfortunately, without some rework, it would be a little difficult to dynamically set the release repository. I don't really want to dynamically touch the `BUILD` or `.bzl` files where I might have the `release_repo` defined that is passed into the rule since that could differ between repos. This change allows the `release_repo` to be overridden from a CLI such that the staging repository can be created dynamically during CI and passed to the deploy target for publishing before dynamically closing & releasing the staging repo.

## What are the changes implemented in this PR?

This is an interesting PR b/c there are a few ways to solve this. I could have modified the `.py` script to try and read from an env var. However, given that this is really a one-off URL, the potential for a stale repo being stored and used from the env was non-zero. Having to manually specify the staging repo w/in the bazel invocation seemed like a good middleground.

Opinions appreciated 😄 