### PR TITLE
Explicitly use python3

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1,7 +1,7 @@
 build:
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       command: |
         bazel build //...

--- a/apt/generate_depends_file.py
+++ b/apt/generate_depends_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/apt/templates/deploy.py
+++ b/apt/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/artifact/templates/deploy.py
+++ b/artifact/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/assemble_versioned/assemble-versioned.py
+++ b/common/assemble_versioned/assemble-versioned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/java_deps/java_deps.py
+++ b/common/java_deps/java_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/common/tgz2zip/tgz2zip.py
+++ b/common/tgz2zip/tgz2zip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/github/templates/deploy.py
+++ b/github/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/npm/assemble/assemble.py
+++ b/npm/assemble/assemble.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/packer/templates/deploy_packer.py
+++ b/packer/templates/deploy_packer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/pip/repackage.py
+++ b/pip/repackage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/pip/replace_imports.py
+++ b/pip/replace_imports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/rpm/generate_spec_file.py
+++ b/rpm/generate_spec_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/rpm/templates/deploy.py
+++ b/rpm/templates/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
## What is the goal of this PR?

We now use the command `python3` explicitly instead of `python`. As all of our code is written in Python 3 and the command `python` is ambiguous for historical reasons, this is more in line with our current approach in using java and bazel. That is, we rely upon the image that is provided to specify the appropriate version of these binaries rather than doing so ourselves.

## What are the changes implemented in this PR?

We have changed every line specifying 
```
#!/usr/bin/env python
```
to
```
#!/usr/bin/env python3
```