### PR TITLE
Make `assemble_crate` version default to its target's version

### DIFF
--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -30,7 +30,7 @@ def _generate_version_file(ctx):
     version_file = ctx.file.version_file
     if not ctx.attr.version_file:
         version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
-        version = ctx.var.get("version", "0.0.0")
+        version = ctx.var.get("version", ctx.attr.target[CrateSummary].version)
 
         ctx.actions.run_shell(
             inputs = [],


### PR DESCRIPTION
## What is the goal of this PR?

We made `assemble_crate`, by default, generate a crate version equal to the `version` field of its `target` (i.e. the `rust_library`, etc. being assembled) 

## What are the changes implemented in this PR?

Previously if we ran `deploy_crate` with no `version_file` or `--version` argument specified, it would deploy crate version `0.0.0`. Now, we deploy whatever version is specified in `assemble_crate`'s `target` (which itself defaults to `0.0.0` if unspecified)