### PR TITLE
Prepend 0.0.0 to the version of `assemble_crate` if it looks like a commit SHA

### DIFF
--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -32,6 +32,10 @@ def _generate_version_file(ctx):
         version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
         version = ctx.var.get("version", ctx.attr.target[CrateSummary].version)
 
+        if len(version) == 40:
+            # this is a commit SHA, most likely
+            version = "0.0.0-{}".format(version)
+
         ctx.actions.run_shell(
             inputs = [],
             outputs = [version_file],


### PR DESCRIPTION
## What is the goal of this PR?

We now prepend `0.0.0` to the version of the crate assembled by `assemble_crate` if it looks like a commit SHA (i.e: is a snapshot crate)

## What are the changes implemented in this PR?

Deployment of snapshot distributions to other repos such as PyPi depends on logic that checks the length of the version, and if it's 40, we assume it's a commit SHA (hence a snapshot crate) and prepend 0.0.0 to it.

We now do the same for crates.