### PR TITLE
Extend NPM deployment with password or token-based deployment

### DIFF
--- a/npm/deploy/Deployer.kt
+++ b/npm/deploy/Deployer.kt
@@ -57,13 +57,16 @@ class Deployer(private val options: Options) {
     }
 
     private fun auth(username: String, password: String): String {
-        return base64URLEncode(username + ":" + password)
+        val base64URLEncode = base64URLEncode(username + ":" + password)
+        print("Encoded: " + base64URLEncode)
+        return base64URLEncode;
     }
 
     private fun base64URLEncode(string: String): String {
-        return Base64.getUrlEncoder()
-                .withoutPadding()
-                .encodeToString(string.toByteArray(StandardCharsets.UTF_8))
+        return Base64.getEncoder().encodeToString(string.toByteArray())
+                //.getUrlEncoder()
+//                .withoutPadding()
+//                .encodeToString(string.toByteArray(StandardCharsets.UTF_8))
     }
 
     private fun pathEnv(): String {

--- a/npm/deploy/Options.kt
+++ b/npm/deploy/Options.kt
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.vaticle.bazel.distribution.npm.deploy
 
 import com.vaticle.bazel.distribution.npm.deploy.Options.CommandLineParams.NPM_PATH
@@ -34,19 +55,16 @@ class Options {
     val npmToken: String?
         get() {
             return System.getenv().get(Env.DEPLOY_NPM_TOKEN);
-//                     throw IllegalArgumentException("Npm token should be passed via \$${Env.DEPLOY_NPM_TOKEN} env variable")
         }
 
     val npmUsername: String?
         get() {
             return System.getenv().get(Env.DEPLOY_NPM_USERNAME)
-//                    ?: throw IllegalArgumentException("Npm username should be passed via \$${Env.DEPLOY_NPM_USERNAME} env variable")
         }
 
     val npmPassword: String?
         get() {
             return System.getenv().get(Env.DEPLOY_NPM_PASSWORD)
-//                ?: throw IllegalArgumentException("Npm password should be passed via \$${Env.DEPLOY_NPM_PASSWORD} env variable")
         }
 
     companion object {

--- a/npm/deploy/Options.kt
+++ b/npm/deploy/Options.kt
@@ -31,16 +31,22 @@ class Options {
             }
         }
 
-    val npmUsername: String
+    val npmToken: String?
         get() {
-            return System.getenv(Env.DEPLOY_NPM_USERNAME)
-                    ?: throw IllegalArgumentException("Npm username should be passed via \$${Env.DEPLOY_NPM_USERNAME} env variable")
+            return System.getenv().get(Env.DEPLOY_NPM_TOKEN);
+//                     throw IllegalArgumentException("Npm token should be passed via \$${Env.DEPLOY_NPM_TOKEN} env variable")
         }
 
-    val npmPassword: String
+    val npmUsername: String?
         get() {
-            return System.getenv(Env.DEPLOY_NPM_PASSWORD)
-                ?: throw IllegalArgumentException("Npm password should be passed via \$${Env.DEPLOY_NPM_PASSWORD} env variable")
+            return System.getenv().get(Env.DEPLOY_NPM_USERNAME)
+//                    ?: throw IllegalArgumentException("Npm username should be passed via \$${Env.DEPLOY_NPM_USERNAME} env variable")
+        }
+
+    val npmPassword: String?
+        get() {
+            return System.getenv().get(Env.DEPLOY_NPM_PASSWORD)
+//                ?: throw IllegalArgumentException("Npm password should be passed via \$${Env.DEPLOY_NPM_PASSWORD} env variable")
         }
 
     companion object {
@@ -72,6 +78,7 @@ class Options {
     }
 
     object Env {
+        const val DEPLOY_NPM_TOKEN = "DEPLOY_NPM_TOKEN"
         const val DEPLOY_NPM_USERNAME = "DEPLOY_NPM_USERNAME"
         const val DEPLOY_NPM_PASSWORD = "DEPLOY_NPM_PASSWORD"
     }

--- a/npm/deploy/Options.kt
+++ b/npm/deploy/Options.kt
@@ -32,10 +32,16 @@ class Options {
             }
         }
 
-    val npmToken: String
+    val npmUsername: String
         get() {
-            return System.getenv(DEPLOY_NPM_TOKEN)
-                ?: throw IllegalArgumentException("token should be passed via \$${DEPLOY_NPM_TOKEN} env variable")
+            return System.getenv(Env.DEPLOY_NPM_USERNAME)
+                    ?: throw IllegalArgumentException("Npm username should be passed via \$${Env.DEPLOY_NPM_USERNAME} env variable")
+        }
+
+    val npmPassword: String
+        get() {
+            return System.getenv(Env.DEPLOY_NPM_PASSWORD)
+                ?: throw IllegalArgumentException("Npm password should be passed via \$${Env.DEPLOY_NPM_PASSWORD} env variable")
         }
 
     companion object {
@@ -67,6 +73,7 @@ class Options {
     }
 
     object Env {
-        const val DEPLOY_NPM_TOKEN = "DEPLOY_NPM_TOKEN"
+        const val DEPLOY_NPM_USERNAME = "DEPLOY_NPM_USERNAME"
+        const val DEPLOY_NPM_PASSWORD = "DEPLOY_NPM_PASSWORD"
     }
 }

--- a/npm/deploy/Options.kt
+++ b/npm/deploy/Options.kt
@@ -3,7 +3,6 @@ package com.vaticle.bazel.distribution.npm.deploy
 import com.vaticle.bazel.distribution.npm.deploy.Options.CommandLineParams.NPM_PATH
 import com.vaticle.bazel.distribution.npm.deploy.Options.CommandLineParams.RELEASE_REPO
 import com.vaticle.bazel.distribution.npm.deploy.Options.CommandLineParams.SNAPSHOT_REPO
-import com.vaticle.bazel.distribution.npm.deploy.Options.Env.DEPLOY_NPM_TOKEN
 import com.vaticle.bazel.distribution.npm.deploy.Options.RepositoryType.RELEASE
 import com.vaticle.bazel.distribution.npm.deploy.Options.RepositoryType.SNAPSHOT
 import picocli.CommandLine


### PR DESCRIPTION
## What is the goal of this PR?

As of January 2023, the `deploy_npm` using npm v8.x rule appears to stop working with pre-generated auth tokens for Sonatype repositories. However, we discover that the simpler mechanism of using base64 encoded username/password does work.

Using the base64 encoded authenciation is also [recommended](https://help.sonatype.com/repomanager3/nexus-repository-administration/formats/npm-registry/npm-security#npmSecurity-AuthenticationUsingBasicAuth) by Sonatype, we can successfully deploy.

However, the deployment to centralised NPM repositories may still require using token-based authentication. As a result, we extend the deployment rule to support both username/password or token-based authentication.

This issue was last worked on in https://github.com/vaticle/bazel-distribution/pull/330

## What are the changes implemented in this PR?

* Introduce the capability to use username+password authentication OR token authentication based on which environment variables are present
