### PR TITLE
Fix pip deployment and extend deploy rule doc strings with usage

### DIFF
--- a/apt/rules.bzl
+++ b/apt/rules.bzl
@@ -185,5 +185,8 @@ deploy_apt = rule(
     },
     implementation = _deploy_apt_impl,
     executable = True,
-    doc = 'Deploy package built with `assemble_apt` to APT repository'
+    doc = """Deploy package built with `assemble_apt` to APT repository.
+
+    Select deployment to `snapshot` or `release` repository with `bazel run //:some-deploy-apt -- [snapshot|release]
+    """
 )

--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -114,5 +114,8 @@ deploy_brew = rule(
         "deployment_script": "%{name}.py"
     },
     implementation = _deploy_brew_impl,
-    doc = "Deploy Homebrew (Caskroom) formula to Homebrew tap"
+    doc = """Deploy Homebrew (Caskroom) formula to Homebrew tap.
+
+    Select deployment to `snapshot` or `release` repository with `bazel run //some-deploy-brew -- [snapshot|release]
+    """
 )

--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -116,6 +116,6 @@ deploy_brew = rule(
     implementation = _deploy_brew_impl,
     doc = """Deploy Homebrew (Caskroom) formula to Homebrew tap.
 
-    Select deployment to `snapshot` or `release` repository with `bazel run //some-deploy-brew -- [snapshot|release]
+    Select deployment to `snapshot` or `release` repository with `bazel run //:some-deploy-brew -- [snapshot|release]
     """
 )

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -371,5 +371,9 @@ deploy_maven = rule(
     },
     executable = True,
     implementation = _deploy_maven_impl,
-    doc = "Deploy `assemble_maven` target into Maven repo"
+    doc = """
+    Deploy `assemble_maven` target into Maven repo.
+
+    Select deployment to `snapshot` or `release` repository with `bazel run //:some-deploy-maven -- [snapshot|release]
+    """
 )

--- a/npm/deploy/rules.bzl
+++ b/npm/deploy/rules.bzl
@@ -75,6 +75,8 @@ deploy_npm = rule(
     doc = """
     Deploy `assemble_npm` target into npm registry using token authentication.
 
+    Select deployment to `snapshot` or `release` repository with `bazel run //:some-deploy-npm -- [snapshot|release]
+
     ## How to generate an auth token
 
     ### Using the command line (`npm adduser`)

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -37,8 +37,8 @@ def create_init_files(directory):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--output_sdist', help="Output archive")
-parser.add_argument('--output_wheel', help="Output archive")
+parser.add_argument('--output_sdist', help="Output targz archive")
+parser.add_argument('--output_wheel', help="Output wheel archive")
 parser.add_argument('--setup_py', help="setup.py")
 parser.add_argument('--requirements_file', help="install_requires")
 parser.add_argument('--readme', help="README file")

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -26,7 +26,8 @@ requests-toolbelt==0.10.1
 rfc3986==2.0.0
 rich==13.2.0
 secretstorage==3.3.3
-setuptools==66.1.1
+### DO NOT UPGRADE - setuptools > 65.x.x removes flexible versioning ###
+setuptools==65.0.0
 six==1.16.0
 tqdm==4.64.1
 twine==4.0.2

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -173,7 +173,7 @@ def _deploy_pip_impl(ctx):
             "{package_file}": ctx.attr.target[PyDeploymentInfo].package.short_path,
             "{wheel_file}": ctx.attr.target[PyDeploymentInfo].wheel.short_path,
             "{version_file}": ctx.attr.target[PyDeploymentInfo].version_file.short_path,
-            "{pyprc_repository}": ctx.attr.pyprc_repository,
+            "{pypirc_repository}": ctx.attr.pypirc_repository,
             "{snapshot}": ctx.attr.snapshot,
             "{release}": ctx.attr.release,
         }
@@ -310,9 +310,9 @@ deploy_pip = rule(
             default = "",
             doc = "Release repository URL to deploy pip artifact to"
         ),
-        "pyprc_repository": attr.string(
+        "pypirc_repository": attr.string(
             default = "",
-            doc = "Repository name in the .pyprc profile to deploy to"
+            doc = "Repository name in the .pypirc profile to deploy to"
         ),
         "_deploy_py_template": attr.label(
             allow_single_file = True,
@@ -345,12 +345,12 @@ deploy_pip = rule(
     doc = """
         Deploy python target to one of multiple provided repositories.
 
-        This rule can be provided with either a `pyprc` repository name to deploy to,
+        This rule can be provided with either a `pypirc` repository name to deploy to,
         or an explicit 'snapshot' or 'release' repository URL to deploy to.
 
-        The `pyprc` must be in the expected location for twine deployment. Typically it is in `$HOME/.pyprc`.
+        The `pypirc` must be in the expected location for twine deployment. Typically it is in `$HOME/.pypirc`.
 
         To deploy to one of these repositories, select it using an argument:
-        ```bazel run //:some-deploy-pip -- [pyprc|snapshot|release]```
+        ```bazel run //:some-deploy-pip -- [pypirc|snapshot|release]```
         """
 )

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -64,25 +64,32 @@ def upload_command(repo_type_key):
         raise Exception(f"Unrecognised repository selector: {repo_type_key}")
 
 
+if not os.path.exists("{package_file}"):
+    raise Exception("Cannot find expected distribution .tar.gz to deploy at '{package_file}'")
+
+if not os.path.exists("{wheel_file}"):
+    raise Exception("Cannot find expected distribution wheel to deploy at '{wheel_file}'")
+
 args = parser.parse_args()
 repo_type_key = args.repo_type
 
 with open("{version_file}") as version_file:
     version = version_file.read().strip()
-new_package_file = None
-new_wheel_file = None
 try:
     if not os.path.exists(dist_dir):
         os.mkdir(dist_dir)
-        
+
     new_package_file = dist_dir + "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
     new_wheel_file = dist_dir + "{wheel_file}".replace(".whl", "-{}.whl".format(version))
 
-    if os.path.exists("{package_file}"):
-        shutil.copy("{package_file}", new_package_file)
+    if not os.path.exists(os.path.dirname(new_package_file)):
+        os.makedirs(os.path.dirname(new_package_file))
 
-    if os.path.exists("{wheel_file}"):
-        shutil.copy("{wheel_file}", new_wheel_file)
+    if not os.path.exists(os.path.dirname(new_wheel_file)):
+        os.makedirs(os.path.dirname(new_wheel_file))
+
+    shutil.copy("{package_file}", new_package_file)
+    shutil.copy("{wheel_file}", new_wheel_file)
 
     twine.commands.upload.main(upload_command(repo_type_key))
 finally:

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -30,7 +30,6 @@ sys.path = runfile_deps + sys.path
 # noinspection PyUnresolvedReferences
 import twine.commands.upload
 
-dist_dir = "./dist"
 PYPIRC_KEY = 'pypirc'
 SNAPSHOT_KEY = 'snapshot'
 RELEASE_KEY = 'release'
@@ -73,12 +72,10 @@ if not os.path.exists("{wheel_file}"):
 args = parser.parse_args()
 repo_type_key = args.repo_type
 
+dist_dir = "./dist"
 with open("{version_file}") as version_file:
     version = version_file.read().strip()
 try:
-    if not os.path.exists(dist_dir):
-        os.mkdir(dist_dir)
-
     new_package_file = dist_dir + "/{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
     new_wheel_file = dist_dir + "/{wheel_file}".replace(".whl", "-{}.whl".format(version))
 

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -30,7 +30,7 @@ sys.path = runfile_deps + sys.path
 # noinspection PyUnresolvedReferences
 import twine.commands.upload
 
-dist_dir = "./dist/"
+dist_dir = "./dist"
 PYPRC_KEY = 'pyprc'
 SNAPSHOT_KEY = 'snapshot'
 RELEASE_KEY = 'release'
@@ -47,19 +47,19 @@ repositories = {
 parser = argparse.ArgumentParser()
 parser.add_argument('repo_type')
 
-def upload_command(repo_type_key):
+def upload_command(repo_type_key, package_file, wheel_file):
     if repo_type_key not in repositories:
         raise Exception(f"Selected repository must be one of: {list(repositories.keys())}")
 
     if repo_type_key == PYPRC_KEY:
-        return [f"{dist_dir}*", '--repository', repositories[repo_type_key]]
+        return [package_file, wheel_file, '--repository', repositories[repo_type_key]]
     elif repo_type_key == SNAPSHOT_KEY or repo_type_key == RELEASE_KEY:
         pip_username, pip_password = (os.getenv(ENV_DEPLOY_PIP_USERNAME), os.getenv(ENV_DEPLOY_PIP_PASSWORD))
         if not pip_username:
             raise Exception(f"username should be passed via the {ENV_DEPLOY_PIP_USERNAME} environment variable")
         if not pip_password:
             raise Exception(f"password should be passed via the {ENV_DEPLOY_PIP_PASSWORD} environment variable")
-        return [f'{dist_dir}*', '-u', pip_username, '-p', pip_password, '--repository-url', repositories[repo_type_key]]
+        return [package_file, wheel_file, '-u', pip_username, '-p', pip_password, '--repository-url', repositories[repo_type_key]]
     else:
         raise Exception(f"Unrecognised repository selector: {repo_type_key}")
 
@@ -79,8 +79,8 @@ try:
     if not os.path.exists(dist_dir):
         os.mkdir(dist_dir)
 
-    new_package_file = dist_dir + "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
-    new_wheel_file = dist_dir + "{wheel_file}".replace(".whl", "-{}.whl".format(version))
+    new_package_file = dist_dir + "/{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
+    new_wheel_file = dist_dir + "/{wheel_file}".replace(".whl", "-{}.whl".format(version))
 
     if not os.path.exists(os.path.dirname(new_package_file)):
         os.makedirs(os.path.dirname(new_package_file))
@@ -91,6 +91,6 @@ try:
     shutil.copy("{package_file}", new_package_file)
     shutil.copy("{wheel_file}", new_wheel_file)
 
-    twine.commands.upload.main(upload_command(repo_type_key))
+    twine.commands.upload.main(upload_command(repo_type_key, new_package_file, new_wheel_file))
 finally:
     shutil.rmtree(dist_dir)

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -31,7 +31,7 @@ sys.path = runfile_deps + sys.path
 import twine.commands.upload
 
 dist_dir = "./dist"
-PYPRC_KEY = 'pyprc'
+PYPIRC_KEY = 'pypirc'
 SNAPSHOT_KEY = 'snapshot'
 RELEASE_KEY = 'release'
 
@@ -39,7 +39,7 @@ ENV_DEPLOY_PIP_USERNAME = 'DEPLOY_PIP_USERNAME'
 ENV_DEPLOY_PIP_PASSWORD = 'DEPLOY_PIP_PASSWORD'
 
 repositories = {
-    PYPRC_KEY: "{pyprc_repository}",
+    PYPIRC_KEY: "{pypirc_repository}",
     SNAPSHOT_KEY: "{snapshot}",
     RELEASE_KEY: "{release}"
 }
@@ -51,7 +51,7 @@ def upload_command(repo_type_key, package_file, wheel_file):
     if repo_type_key not in repositories:
         raise Exception(f"Selected repository must be one of: {list(repositories.keys())}")
 
-    if repo_type_key == PYPRC_KEY:
+    if repo_type_key == PYPIRC_KEY:
         return [package_file, wheel_file, '--repository', repositories[repo_type_key]]
     elif repo_type_key == SNAPSHOT_KEY or repo_type_key == RELEASE_KEY:
         pip_username, pip_password = (os.getenv(ENV_DEPLOY_PIP_USERNAME), os.getenv(ENV_DEPLOY_PIP_PASSWORD))

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -30,41 +30,53 @@ sys.path = runfile_deps + sys.path
 # noinspection PyUnresolvedReferences
 import twine.commands.upload
 
-pypi_profile = "{pypi_profile}"
-pip_registry = "{snapshot}" if "{snapshot}" else "{release}"
+dist_dir = "./dist/"
+PYPRC_KEY = 'pyprc'
+SNAPSHOT_KEY = 'snapshot'
+RELEASE_KEY = 'release'
 
-if pypi_profile:
-    command = ['./dist/*', '--repository', pypi_profile]
-else:
-    pip_username, pip_password = (
-        os.getenv('DEPLOY_PIP_USERNAME'),
-        os.getenv('DEPLOY_PIP_PASSWORD'),
-    )
+ENV_DEPLOY_PIP_USERNAME = 'DEPLOY_PIP_USERNAME'
+ENV_DEPLOY_PIP_PASSWORD = 'DEPLOY_PIP_PASSWORD'
 
-    if not pip_username:
-        raise Exception(
-            'username should be passed via '
-            'DEPLOY_PIP_USERNAME env variable'
-        )
+repositories = {
+    PYPRC_KEY: "{pyprc_repository}",
+    SNAPSHOT_KEY: "{snapshot}",
+    RELEASE_KEY: "{release}"
+}
 
-    if not pip_password:
-        raise Exception(
-            'password should be passed via '
-            '$DEPLOY_PIP_PASSWORD env variable'
-        )
-    command = ['./dist/*', '-u', pip_username, '-p', pip_password, '--repository-url', pip_registry]
+parser = argparse.ArgumentParser()
+parser.add_argument('repo_type')
+
+def upload_command(repo_type_key):
+    if repo_type_key not in repositories:
+        raise Exception(f"Selected repository must be one of: {list(repositories.keys())}")
+
+    if repo_type_key == PYPRC_KEY:
+        return [f"{dist_dir}*", '--repository', repositories[repo_type_key]]
+    elif repo_type_key == SNAPSHOT_KEY or repo_type_key == RELEASE_KEY:
+        pip_username, pip_password = (os.getenv(ENV_DEPLOY_PIP_USERNAME), os.getenv(ENV_DEPLOY_PIP_PASSWORD))
+        if not pip_username:
+            raise Exception(f"username should be passed via the {ENV_DEPLOY_PIP_USERNAME} environment variable")
+        if not pip_password:
+            raise Exception(f"password should be passed via the {ENV_DEPLOY_PIP_PASSWORD} environment variable")
+        return [f'{dist_dir}*', '-u', pip_username, '-p', pip_password, '--repository-url', repositories[repo_type_key]]
+    else:
+        raise Exception(f"Unrecognised repository selector: {repo_type_key}")
+
+
+args = parser.parse_args()
+repo_type_key = args.repo_type
 
 with open("{version_file}") as version_file:
     version = version_file.read().strip()
 new_package_file = None
 new_wheel_file = None
 try:
-    dist_prefix = "./dist/"
-    if not os.path.exists(dist_prefix):
-        os.mkdir(dist_prefix)
+    if not os.path.exists(dist_dir):
+        os.mkdir(dist_dir)
         
-    new_package_file = dist_prefix + "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
-    new_wheel_file = dist_prefix + "{wheel_file}".replace(".whl", "-{}.whl".format(version))
+    new_package_file = dist_dir + "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
+    new_wheel_file = dist_dir + "{wheel_file}".replace(".whl", "-{}.whl".format(version))
 
     if os.path.exists("{package_file}"):
         shutil.copy("{package_file}", new_package_file)
@@ -72,6 +84,6 @@ try:
     if os.path.exists("{wheel_file}"):
         shutil.copy("{wheel_file}", new_wheel_file)
 
-    twine.commands.upload.main(command)
+    twine.commands.upload.main(upload_command(repo_type_key))
 finally:
-    shutil.rmtree(dist_prefix)
+    shutil.rmtree(dist_dir)

--- a/rpm/rules.bzl
+++ b/rpm/rules.bzl
@@ -224,5 +224,8 @@ deploy_rpm = rule(
     },
     implementation = _deploy_rpm_impl,
     executable = True,
-    doc = 'Deploy package built with `assemble_rpm` to RPM repository'
+    doc = """Deploy package built with `assemble_rpm` to RPM repository.
+
+    Select deployment to `snapshot` or `release` repository with `bazel run //:some-deploy-rpm -- [snapshot|release]
+    """
 )


### PR DESCRIPTION
## What is the goal of this PR?

The `deploy_pip` rule was modified by #368 to allow deploying wheels and targz packages to repositories provided by a `pypirc` file. However, this broke this repository's consistent design: every `deploy_*` rule provides all possible repositories to upload to (eg. using `snapshot` or `release`), then selects which one to deploy to at run time using arguments.

This PR revert some changes to the `deploy_pip` rule to make it conform to this consistent design. We also fix some bugs during the upload process. 

Finally, we extend the doc strings for each of the deploy rules to indicate how to select the repository to deploy to. 

### `deploy_pip` changes

The `deploy_pip` rule is changed to take multiple different destination repositories to upload to. These are provided, as before, using the existing `snapshot` or `release` attributes. The additional attribute of `pypirc_repository` (renamed from `pypi_profile`) is made available in the same way, rather than with an exclusive-or logic.

Now we declare `deploy_pip` targets like this:

```
deploy_pip(
  name = "some-deploy-pip",
  snapshot = "https://... snapshot ...",
  release = "https:// ... release ...",
  pypirc_repository = "some-repository-name"
)
```

The `pypirc_repository` attribute refers the name of a repository declared in a [pyripc file](https://packaging.python.org/en/latest/specifications/pypirc/). This configuration file is an external file normally exists in a standard location such as `$HOME/.pypirc`.

After this change, deployment looks like this:
```
bazel run //:some-deploy-pip -- [pypirc|snapshot|release]
```

All deployment rules in this repository should continue to support declaring multiple target repositories in this manner, for the time being.

## What are the changes implemented in this PR?

* Add doc strings to show how to use deployment rules for either snapshot or release
* Refactor `deploy_pip` to be consistent with the existing style, in which all potential deployment repositories are declared by attribute and the relevant one is selected as an argument to `bazel run //... -- [arg]`
* Fix the upload of the `.tar.gz` and `.whl` packages to the target repository, which was failing because of non-existent paths
* Downgrade `setuptools` to version `65.0.0`, which still allows non-semantic versioned packages to distributed
 and is a requirement for Vaticle for now
