### PR TITLE
Use PEP491 naming conventions for wheel deployments to pip

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -96,6 +96,9 @@ def _assemble_pip_impl(ctx):
          if 'pypi' not in i.path and 'external' not in i.path and i.extension != "py":
             data_files.append(i)
 
+    if ctx.attr.python_requires.startswith(">2.") or ctx.attr.python_requires.startswith("=2."):
+        fail("This rule only supports Python 3.x, was given 'python_requires = " + ctx.attr.python_requires + "'.")
+
     args.add_all('--files', python_source_files)
     args.add_all('--data_files', data_files)
     args.add('--output_sdist', ctx.outputs.pip_package.path)

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -77,17 +77,17 @@ with open("{version_file}") as version_file:
     version = version_file.read().strip()
 try:
     new_package_file = dist_dir + "/{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
-    new_wheel_file = dist_dir + "/{wheel_file}".replace(".whl", "-{}.whl".format(version))
+    new_wheel_pep491 = dist_dir + "/{wheel_file}".replace("-", "_").replace(".whl", "-{}-py3-none-any.whl".format(version))
 
     if not os.path.exists(os.path.dirname(new_package_file)):
         os.makedirs(os.path.dirname(new_package_file))
 
-    if not os.path.exists(os.path.dirname(new_wheel_file)):
-        os.makedirs(os.path.dirname(new_wheel_file))
+    if not os.path.exists(os.path.dirname(new_wheel_pep491)):
+        os.makedirs(os.path.dirname(new_wheel_pep491))
 
     shutil.copy("{package_file}", new_package_file)
-    shutil.copy("{wheel_file}", new_wheel_file)
+    shutil.copy("{wheel_file}", new_wheel_pep491)
 
-    twine.commands.upload.main(upload_command(repo_type_key, new_package_file, new_wheel_file))
+    twine.commands.upload.main(upload_command(repo_type_key, new_package_file, new_wheel_pep491))
 finally:
     shutil.rmtree(dist_dir)


### PR DESCRIPTION
## What is the goal of this PR?

The new functionality introduced in #368 to deploy wheels did not introduce the right naming convention for wheels - PyPi for example will decline packages not naming according to the [PIP491](https://peps.python.org/pep-0491/).

This PR restricts the `assemble_pip` to only produce `py3` type archives, which can then be deployed with the required naming convention.

## What are the changes implemented in this PR?

* Restrict `assemble_pip` to only allow Python-3 compatibility
* `deploy_pip` produces wheels that conform to `{name}-{version}-{pyversion}-{abi}-{platform}` by hardcoding it to `{name}-{version}-py3-none-any`
