### PR TITLE
Allow java deps to filter out remote or local JDK jars

### DIFF
--- a/common/java_deps/rules.bzl
+++ b/common/java_deps/rules.bzl
@@ -108,7 +108,7 @@ _transitive_collect_maven_coordinate = aspect(
 
 
 def _is_jdk_jar(file):
-    return not file.path.startswith(LOCAL_JDK_PREFIX) and not file.path.startswith(REMOTE_JDK_PREFIX)
+    return file.path.startswith(LOCAL_JDK_PREFIX) or file.path.startswith(REMOTE_JDK_PREFIX)
 
 
 def _java_deps_impl(ctx):

--- a/common/java_deps/rules.bzl
+++ b/common/java_deps/rules.bzl
@@ -17,7 +17,8 @@
 # under the License.
 #
 
-LOCAL_JDK_PREFIX = "external/local_jdk/"
+LOCAL_JDK_PREFIX = "external/local_jdk"
+REMOTE_JDK_PREFIX = "external/remotejdk"
 MAVEN_COORDINATES_PREFIX = "maven_coordinates="
 
 # mapping of single JAR to its Maven coordinates
@@ -106,6 +107,10 @@ _transitive_collect_maven_coordinate = aspect(
 )
 
 
+def _is_jdk_jar(file):
+    return not file.path.startswith(LOCAL_JDK_PREFIX) and not file.path.startswith(REMOTE_JDK_PREFIX)
+
+
 def _java_deps_impl(ctx):
     full_output_paths = {}
     jars_by_output_path = {}
@@ -114,7 +119,7 @@ def _java_deps_impl(ctx):
     mapping = ctx.attr.target[TransitiveJarToMavenCoordinatesMapping].mapping
 
     for file in ctx.attr.target.data_runfiles.files.to_list():
-        if file.extension == "jar" and not file.path.startswith(LOCAL_JDK_PREFIX):
+        if file.extension == "jar" and not _is_jdk_jar(file):
             if ctx.attr.maven_name and file.path not in mapping:
                 fail("{} does not have associated Maven coordinate".format(file.owner))
             output_path = mapping.get(file.path, default=file.basename).replace('.', '-').replace(':', '-')


### PR DESCRIPTION
## What is the goal of this PR?

In the collection of transitive maven dependencies for Java, we ignore all JARs available in the JDK that is chosen. This is extended to allow ignoring of JARs coming from the remote JDK or the local JDK. Use of the remote JDK in Bazel ensures hermiticity in some systems, which is a desirable option to have.

## What are the changes implemented in this PR?

* Allow java-deps to skip jars included in either the remote or local JDK