### PR TITLE
Emit canonical dependency info when assembling crate

### DIFF
--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -92,7 +92,7 @@ def _assemble_crate_impl(ctx):
         args.append("--documentation")
         args.append(ctx.attr.documentation)
     if ctx.attr.crate_features:
-        args.append("--features")
+        args.append("--crate-features")
         args.append(";".join([
             "{}={}".format(feature, ",".join(implied)) if implied else feature
             for feature, implied in ctx.attr.crate_features.items()


### PR DESCRIPTION
## What is the goal of this PR?

We improve the generated crate manifest by allowing to specify available crate features, and by enabling the features of dependencies.

## What are the changes implemented in this PR?

We did not include enabled features in the crate dependencies before this change. Now, we parse the crate universe manifests and collect the `crate_features` attributes from the `rust_library` dependencies of the crate being assembled so that we can emit the correct dependency requirement in the generated Cargo.toml. 

`rules_rust` must resolve the full list of features which were enabled explicitly or implicitly in order to correctly compile the dependency. That has the consequence of us ultimately explicitly depending on implementation details of other crates (see e.g. https://github.com/vaticle/typedb-driver-rust/issues/35), which is misleading on the crates.io page, and breaks across dependency versions. For this reason, we cannot simply rely on the `crate_features` attribute of the generated dependency files, but must instead parse the explicitly enabled features in the universe manifests.