### PR TITLE
Update Maven rules to support platform profiles and Windows deployment

### DIFF
--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -193,7 +193,7 @@ class PomGenerator : Callable<Unit> {
     fun profiles(pom: Document, version: String, workspace_refs: JsonObject): Element {
         val ARCH_LIST = mapOf(
                 "x86_64" to arrayOf("x86_64", "x86-64", "amd64"),
-                "arm64" to arrayOf("arm64", "aarch64"),
+                "aarch64" to arrayOf("arm64", "aarch64"),
         )
 
         val profilesElem = pom.createElement("profiles")

--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -78,6 +78,9 @@ class PomGenerator : Callable<Unit> {
     @Option(names = ["--target_deps_coordinates"])
     lateinit var dependencyCoordinates: String
 
+    @Option(names = ["--profiles"])
+    var profilesSpec: String = ""
+
     fun getLicenseInfo(license_id: String): Pair<String, String> {
         return when {
             license_id.equals("apache") -> {
@@ -165,9 +168,9 @@ class PomGenerator : Callable<Unit> {
         return scm
     }
 
-    fun dependencies(pom: Document, version: String, workspace_refs: JsonObject): Element {
+    fun dependencies(pom: Document, version: String, workspace_refs: JsonObject, dependencies: String): Element {
         val dependenciesElem = pom.createElement("dependencies")
-        val coordinates = if (dependencyCoordinates.length == 0) emptyArray<String>() else dependencyCoordinates.split(";").toTypedArray()
+        val coordinates = if (dependencies.isEmpty()) emptyArray() else dependencies.split(";").toTypedArray()
         for (dep in coordinates) {
             val depCoordinates = parseMavenCoordinate(dep)
             val dependencyElem = pom.createElement("dependency")
@@ -185,6 +188,39 @@ class PomGenerator : Callable<Unit> {
             dependenciesElem.appendChild(dependencyElem)
         }
         return dependenciesElem
+    }
+
+    fun profiles(pom: Document, version: String, workspace_refs: JsonObject): Element {
+        val profilesElem = pom.createElement("profiles")
+        val profiles = if (profilesSpec.isEmpty()) emptyArray() else profilesSpec.split(";").toTypedArray()
+        for (profile in profiles) {
+            val (id, dependencies) = profile.split("#", limit = 2)
+            val (os, arch) = id.split(",", limit = 2)
+            val profileElem = pom.createElement("profile")
+
+            val idElem = pom.createElement("id")
+            idElem.appendChild(pom.createTextNode("$os-$arch"))
+            profileElem.appendChild(idElem)
+
+            val activationElem = pom.createElement("activation")
+            val osElem = pom.createElement("os")
+
+            val familyElem = pom.createElement("family")
+            familyElem.appendChild(pom.createTextNode(os))
+            osElem.appendChild(familyElem)
+
+            val archElem = pom.createElement("arch")
+            archElem.appendChild(pom.createTextNode(arch))
+            osElem.appendChild(archElem)
+
+            activationElem.appendChild(osElem)
+            profileElem.appendChild(activationElem)
+
+            profileElem.appendChild(dependencies(pom, version, workspace_refs, dependencies))
+
+            profilesElem.appendChild(profileElem)
+        }
+        return profilesElem
     }
 
     private fun outputDocumentToFile(pom: Document) {
@@ -253,7 +289,9 @@ class PomGenerator : Callable<Unit> {
         rootElement.appendChild(versionElem)
 
         // add dependency information
-        rootElement.appendChild(dependencies(pom, version, workspace_refs))
+        rootElement.appendChild(dependencies(pom, version, workspace_refs, dependencyCoordinates))
+
+        rootElement.appendChild(profiles(pom, version, workspace_refs))
 
         // write the final result
         outputDocumentToFile(pom)

--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -191,34 +191,41 @@ class PomGenerator : Callable<Unit> {
     }
 
     fun profiles(pom: Document, version: String, workspace_refs: JsonObject): Element {
+        val ARCH_LIST = mapOf(
+                "x86_64" to arrayOf("x86_64", "x86-64", "amd64"),
+                "arm64" to arrayOf("arm64", "aarch64"),
+        )
+
         val profilesElem = pom.createElement("profiles")
         val profiles = if (profilesSpec.isEmpty()) emptyArray() else profilesSpec.split(";").toTypedArray()
         for (profile in profiles) {
             val (id, dependencies) = profile.split("#", limit = 2)
-            val (os, arch) = id.split(",", limit = 2)
-            val profileElem = pom.createElement("profile")
+            val (os, baseArch) = id.split("-", limit = 2)
+            for (arch in ARCH_LIST[baseArch]!!) {
+                val profileElem = pom.createElement("profile")
 
-            val idElem = pom.createElement("id")
-            idElem.appendChild(pom.createTextNode("$os-$arch"))
-            profileElem.appendChild(idElem)
+                val idElem = pom.createElement("id")
+                idElem.appendChild(pom.createTextNode("$os-$arch"))
+                profileElem.appendChild(idElem)
 
-            val activationElem = pom.createElement("activation")
-            val osElem = pom.createElement("os")
+                val activationElem = pom.createElement("activation")
+                val osElem = pom.createElement("os")
 
-            val familyElem = pom.createElement("family")
-            familyElem.appendChild(pom.createTextNode(os))
-            osElem.appendChild(familyElem)
+                val familyElem = pom.createElement("family")
+                familyElem.appendChild(pom.createTextNode(os))
+                osElem.appendChild(familyElem)
 
-            val archElem = pom.createElement("arch")
-            archElem.appendChild(pom.createTextNode(arch))
-            osElem.appendChild(archElem)
+                val archElem = pom.createElement("arch")
+                archElem.appendChild(pom.createTextNode(arch))
+                osElem.appendChild(archElem)
 
-            activationElem.appendChild(osElem)
-            profileElem.appendChild(activationElem)
+                activationElem.appendChild(osElem)
+                profileElem.appendChild(activationElem)
 
-            profileElem.appendChild(dependencies(pom, version, workspace_refs, dependencies))
+                profileElem.appendChild(dependencies(pom, version, workspace_refs, dependencies))
 
-            profilesElem.appendChild(profileElem)
+                profilesElem.appendChild(profileElem)
+            }
         }
         return profilesElem
     }

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -397,7 +397,7 @@ deploy_maven_inner = rule(
 )
 
 def deploy_maven(name, target, snapshot, release, **kwargs):
-    target_name = name + "_gen"
+    target_name = name + "__gen"
 
     deploy_maven_inner(
         name = target_name,
@@ -410,4 +410,5 @@ def deploy_maven(name, target, snapshot, release, **kwargs):
     native.py_binary(
         name = name,
         srcs = [target_name],
+        main = target_name + "-deploy.py",
     )

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -299,7 +299,22 @@ assemble_maven = rule(
             aspects = [
                 aggregate_dependency_info,
             ],
-            doc = "TODO",
+            doc = """
+Per-profile overrides for a dependency. Expects a dict of bazel labels to a JSON-encoded dictionary of platform to maven coordinates.
+Ex.:
+assemble_maven(
+    ...
+    profile_overrides = {
+        ":bazel-dependency": json.encode({
+            "windows-x86_64": "org.company:dependency-windows-x86_64:{pom_version}",
+            "linux-aarch64": "org.company:dependency-linux-aarch64:{pom_version}",
+            "linux-x86_64": "org.company:dependency-linux-x86_64:{pom_version}",
+            "mac-aarch64": "org.company:dependency-macosx-aarch64:{pom_version}",
+            "mac-x86_64": "org.company:dependency-macosx-x86_64:{pom_version}",
+        })
+    }
+)
+            """,
         ),
         "_pom_generator": attr.label(
             default = "@vaticle_bazel_distribution//maven:pom-generator",

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -47,7 +47,7 @@ def _generate_version_file(ctx):
 
 def _platform_id_to_activation(id):
     OS_FAMILY = { "linux": "linux", "macosx": "mac", "windows": "windows" }
-    OS_ARCH = { "aarch64": "aarch64", "x86_64": "x86_64" }
+    OS_ARCH = { "aarch64": "aarch64", "x86_64": "amd64" }
 
     id_family, id_arch = id.split("-", 1)
     return OS_FAMILY[id_family], OS_ARCH[id_arch]

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -113,7 +113,7 @@ def _generate_class_jar(ctx, pom_file):
     else:
         fail("Could not find JAR file to deploy in {}".format(target))
 
-    output_jar = ctx.actions.declare_file("{}:{}.jar".format(maven_coordinates.group_id, maven_coordinates.artifact_id))
+    output_jar = ctx.actions.declare_file("{}-{}.jar".format(maven_coordinates.group_id, maven_coordinates.artifact_id))
 
     class_jar_deps = [dep.class_jar for dep in target[JarInfo].deps.to_list() if dep.type == 'jar']
     class_jar_paths = [jar.path] + [target.path for target in class_jar_deps]
@@ -150,7 +150,7 @@ def _generate_source_jar(ctx):
     if not srcjar:
         return None
 
-    output_jar = ctx.actions.declare_file("{}:{}-sources.jar".format(maven_coordinates.group_id, maven_coordinates.artifact_id))
+    output_jar = ctx.actions.declare_file("{}-{}-sources.jar".format(maven_coordinates.group_id, maven_coordinates.artifact_id))
 
     source_jar_deps = [dep.source_jar for dep in target[JarInfo].deps.to_list() if dep.type == 'jar' and dep.source_jar]
     source_jar_paths = [srcjar.path] + [target.path for target in source_jar_deps]

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -367,7 +367,7 @@ def _deploy_maven_impl(ctx):
         runfiles = ctx.runfiles(files=files, symlinks = symlinks)
     )
 
-deploy_maven = rule(
+deploy_maven_inner = rule(
     attrs = {
         "target": attr.label(
             mandatory = True,
@@ -395,3 +395,19 @@ deploy_maven = rule(
     Select deployment to `snapshot` or `release` repository with `bazel run //:some-deploy-maven -- [snapshot|release]
     """
 )
+
+def deploy_maven(name, target, snapshot, release, **kwargs):
+    target_name = name + "_gen"
+
+    deploy_maven_inner(
+        name = target_name,
+        target = target,
+        snapshot = snapshot,
+        release = release,
+        **kwargs
+    )
+
+    native.py_binary(
+        name = name,
+        srcs = [target_name],
+    )

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -301,6 +301,8 @@ assemble_maven = rule(
             ],
             doc = """
 Per-profile overrides for a dependency. Expects a dict of bazel labels to a JSON-encoded dictionary of platform to maven coordinates.
+Supported OS: windows, linux, mac
+Supported architectures: x86_64, aarch64
 Ex.:
 assemble_maven(
     ...

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -367,7 +367,7 @@ def _deploy_maven_impl(ctx):
         runfiles = ctx.runfiles(files=files, symlinks = symlinks)
     )
 
-deploy_maven_inner = rule(
+_deploy_maven = rule(
     attrs = {
         "target": attr.label(
             mandatory = True,
@@ -397,9 +397,9 @@ deploy_maven_inner = rule(
 )
 
 def deploy_maven(name, target, snapshot, release, **kwargs):
-    target_name = name + "__gen"
+    target_name = name + "__deploy"
 
-    deploy_maven_inner(
+    _deploy_maven(
         name = target_name,
         target = target,
         snapshot = snapshot,

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -145,35 +145,35 @@ if os.path.exists(srcjar_path):
     if should_sign:
         upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_md5:
+with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as pom_md5:
     pom_md5.write(md5(pom_file_path))
     pom_md5.flush()
     upload(maven_url, username, password, pom_md5.name, filename_base + '.pom.md5')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_sha1:
+with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as pom_sha1:
     pom_sha1.write(sha1(pom_file_path))
     pom_sha1.flush()
     upload(maven_url, username, password, pom_sha1.name, filename_base + '.pom.sha1')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_md5:
+with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as jar_md5:
     jar_md5.write(md5(jar_path))
     jar_md5.flush()
     upload(maven_url, username, password, jar_md5.name, filename_base + '.jar.md5')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_sha1:
+with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as jar_sha1:
     jar_sha1.write(sha1(jar_path))
     jar_sha1.flush()
     upload(maven_url, username, password, jar_sha1.name, filename_base + '.jar.sha1')
 
 if os.path.exists(srcjar_path):
-    with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_md5:
+    with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as srcjar_md5:
         srcjar_md5.write(md5(srcjar_path))
         srcjar_md5.flush()
         upload(maven_url, username, password, srcjar_md5.name, filename_base + '-sources.jar.md5')
         # TODO(vmax): use checksum of real Javadoc instead of srcjar
         upload(maven_url, username, password, srcjar_md5.name, filename_base + '-javadoc.jar.md5')
 
-    with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_sha1:
+    with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as srcjar_sha1:
         srcjar_sha1.write(sha1(srcjar_path))
         srcjar_sha1.flush()
         upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-sources.jar.sha1')

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -41,7 +41,7 @@ def md5(fn):
 
 def upload(url, username, password, local_fn, remote_fn):
     upload_status_code = sp.check_output([
-        'curl', '--silent', '--output', '/dev/stderr',
+        'curl', '--silent',
         '--write-out', '%{http_code}',
         '-u', '{}:{}'.format(username, password),
         '--upload-file', local_fn,

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -58,11 +58,9 @@ def upload_str(url, username, password, string, remote_fn):
         'curl', '--silent',
         '--write-out', '%{http_code}',
         '-u', '{}:{}'.format(username, password),
-        '-X', 'PUT',
-        '-H', 'Content-Type: text/plain;'
-        '-d', string,
+        '--upload-file', '-',
         urljoin(url, remote_fn)
-    ]).decode().strip()
+    ], input=string.encode()).decode().strip()
 
     if upload_status_code not in {'200', '201'}:
         raise Exception('upload_str of "{}" failed, got HTTP status code {}'.format(

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -29,7 +29,6 @@ import subprocess as sp
 import sys
 import tempfile
 from posixpath import join as urljoin
-from pathlib import Path
 
 
 def sha1(fn):
@@ -40,7 +39,7 @@ def md5(fn):
     return hashlib.md5(open(fn, 'rb').read()).hexdigest()
 
 
-def upload(url, username, password, local_fn, remote_fn):
+def upload_file(url, username, password, local_fn, remote_fn):
     upload_status_code = sp.check_output([
         'curl', '--silent',
         '--write-out', '%{http_code}',
@@ -50,8 +49,24 @@ def upload(url, username, password, local_fn, remote_fn):
     ]).decode().strip()
 
     if upload_status_code not in {'200', '201'}:
-        raise Exception('upload of {} failed, got HTTP status code {}'.format(
+        raise Exception('upload_file of {} failed, got HTTP status code {}'.format(
             local_fn, upload_status_code))
+
+
+def upload_str(url, username, password, string, remote_fn):
+    upload_status_code = sp.check_output([
+        'curl', '--silent',
+        '--write-out', '%{http_code}',
+        '-u', '{}:{}'.format(username, password),
+        '-X', 'PUT',
+        '-H', 'Content-Type: text/plain;'
+        '-d', string,
+        urljoin(url, remote_fn)
+    ]).decode().strip()
+
+    if upload_status_code not in {'200', '201'}:
+        raise Exception('upload_str of "{}" failed, got HTTP status code {}'.format(
+            string, upload_status_code))
 
 
 def sign(fn):
@@ -131,52 +146,29 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
     coordinates=group_id.text.replace('.', '/'), version=version, artifact=artifact_id.text)
 
-upload(maven_url, username, password, jar_path, filename_base + '.jar')
+upload_file(maven_url, username, password, jar_path, filename_base + '.jar')
 if should_sign:
-    upload(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
-upload(maven_url, username, password, pom_file_path, filename_base + '.pom')
+    upload_file(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
+upload_file(maven_url, username, password, pom_file_path, filename_base + '.pom')
 if should_sign:
-    upload(maven_url, username, password, sign(pom_file_path), filename_base + '.pom.asc')
+    upload_file(maven_url, username, password, sign(pom_file_path), filename_base + '.pom.asc')
 if os.path.exists(srcjar_path):
-    upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
+    upload_file(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
     if should_sign:
-        upload(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
+        upload_file(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
     # TODO(vmax): use real Javadoc instead of srcjar
-    upload(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
+    upload_file(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
     if should_sign:
-        upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
+        upload_file(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as pom_md5:
-    pom_md5.write(md5(pom_file_path))
-    pom_md5.flush()
-    upload(maven_url, username, password, Path(pom_md5.name).name, filename_base + '.pom.md5')
-
-with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as pom_sha1:
-    pom_sha1.write(sha1(pom_file_path))
-    pom_sha1.flush()
-    upload(maven_url, username, password, Path(pom_sha1.name).name, filename_base + '.pom.sha1')
-
-with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as jar_md5:
-    jar_md5.write(md5(jar_path))
-    jar_md5.flush()
-    upload(maven_url, username, password, Path(jar_md5.name).name, filename_base + '.jar.md5')
-
-with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as jar_sha1:
-    jar_sha1.write(sha1(jar_path))
-    jar_sha1.flush()
-    upload(maven_url, username, password, Path(jar_sha1.name).name, filename_base + '.jar.sha1')
+upload_str(maven_url, username, password, md5(pom_file_path), filename_base + '.pom.md5')
+upload_str(maven_url, username, password, sha1(pom_file_path), filename_base + '.pom.sha1')
+upload_str(maven_url, username, password, md5(jar_path), filename_base + '.jar.md5')
+upload_str(maven_url, username, password, sha1(jar_path), filename_base + '.jar.sha1')
 
 if os.path.exists(srcjar_path):
-    with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as srcjar_md5:
-        srcjar_md5.write(md5(srcjar_path))
-        srcjar_md5.flush()
-        upload(maven_url, username, password, Path(srcjar_md5.name).name, filename_base + '-sources.jar.md5')
-        # TODO(vmax): use checksum of real Javadoc instead of srcjar
-        upload(maven_url, username, password, Path(srcjar_md5.name).name, filename_base + '-javadoc.jar.md5')
+    upload_str(maven_url, username, password, md5(srcjar_path), filename_base + '-sources.jar.md5')
+    upload_str(maven_url, username, password, sha1(srcjar_path), filename_base + '-sources.jar.sha1')
 
-    with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as srcjar_sha1:
-        srcjar_sha1.write(sha1(srcjar_path))
-        srcjar_sha1.flush()
-        upload(maven_url, username, password, Path(srcjar_sha1.name).name, filename_base + '-sources.jar.sha1')
-        # TODO(vmax): use checksum of real Javadoc instead of srcjar
-        upload(maven_url, username, password, Path(srcjar_sha1.name).name, filename_base + '-javadoc.jar.sha1')
+    upload_str(maven_url, username, password, md5(srcjar_path), filename_base + '-javadoc.jar.md5')
+    upload_str(maven_url, username, password, sha1(srcjar_path), filename_base + '-javadoc.jar.sha1')

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -29,6 +29,7 @@ import subprocess as sp
 import sys
 import tempfile
 from posixpath import join as urljoin
+from pathlib import Path
 
 
 def sha1(fn):
@@ -148,34 +149,34 @@ if os.path.exists(srcjar_path):
 with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as pom_md5:
     pom_md5.write(md5(pom_file_path))
     pom_md5.flush()
-    upload(maven_url, username, password, pom_md5.name, filename_base + '.pom.md5')
+    upload(maven_url, username, password, Path(pom_md5.name).name, filename_base + '.pom.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as pom_sha1:
     pom_sha1.write(sha1(pom_file_path))
     pom_sha1.flush()
-    upload(maven_url, username, password, pom_sha1.name, filename_base + '.pom.sha1')
+    upload(maven_url, username, password, Path(pom_sha1.name).name, filename_base + '.pom.sha1')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as jar_md5:
     jar_md5.write(md5(jar_path))
     jar_md5.flush()
-    upload(maven_url, username, password, jar_md5.name, filename_base + '.jar.md5')
+    upload(maven_url, username, password, Path(jar_md5.name).name, filename_base + '.jar.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as jar_sha1:
     jar_sha1.write(sha1(jar_path))
     jar_sha1.flush()
-    upload(maven_url, username, password, jar_sha1.name, filename_base + '.jar.sha1')
+    upload(maven_url, username, password, Path(jar_sha1.name).name, filename_base + '.jar.sha1')
 
 if os.path.exists(srcjar_path):
     with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as srcjar_md5:
         srcjar_md5.write(md5(srcjar_path))
         srcjar_md5.flush()
-        upload(maven_url, username, password, srcjar_md5.name, filename_base + '-sources.jar.md5')
+        upload(maven_url, username, password, Path(srcjar_md5.name).name, filename_base + '-sources.jar.md5')
         # TODO(vmax): use checksum of real Javadoc instead of srcjar
-        upload(maven_url, username, password, srcjar_md5.name, filename_base + '-javadoc.jar.md5')
+        upload(maven_url, username, password, Path(srcjar_md5.name).name, filename_base + '-javadoc.jar.md5')
 
     with tempfile.NamedTemporaryFile(mode='wt', delete=True, dir=os.getcwd()) as srcjar_sha1:
         srcjar_sha1.write(sha1(srcjar_path))
         srcjar_sha1.flush()
-        upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-sources.jar.sha1')
+        upload(maven_url, username, password, Path(srcjar_sha1.name).name, filename_base + '-sources.jar.sha1')
         # TODO(vmax): use checksum of real Javadoc instead of srcjar
-        upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-javadoc.jar.sha1')
+        upload(maven_url, username, password, Path(srcjar_sha1.name).name, filename_base + '-javadoc.jar.sha1')


### PR DESCRIPTION
## What is the goal of this PR?

We update deployment and assembly rules to be invokable on Windows, and to support per-platform profiles in pom.xml.

Per-platform overrides expects a dict of bazel labels to a JSON-encoded dictionary of platform to maven coordinates.
Supported OS: windows, linux, mac
Supported architectures: x86_64, aarch64
Ex.:
```
assemble_maven(
    ...
    profile_overrides = {
        ":bazel-dependency": json.encode({
            "windows-x86_64": "org.company:dependency-windows-x86_64:{pom_version}",
            "linux-aarch64": "org.company:dependency-linux-aarch64:{pom_version}",
            "linux-x86_64": "org.company:dependency-linux-x86_64:{pom_version}",
            "mac-aarch64": "org.company:dependency-macosx-aarch64:{pom_version}",
            "mac-x86_64": "org.company:dependency-macosx-x86_64:{pom_version}",
        })
    }
)
```

## What are the changes implemented in this PR?

- improve portability of maven assembly and deployment rules,
- add the ability to specify per-platform profiles.