### PR TITLE
Update artifact extractor to be compatible with updated rules_pkg

### DIFF
--- a/artifact/rules.bzl
+++ b/artifact/rules.bzl
@@ -159,7 +159,7 @@ then
     unzip -qq {artifact_location} -d $tmp_dir
     mv -v $tmp_dir/*/* $BUILD_WORKSPACE_DIRECTORY/$1/
 else
-    tar -xzf {artifact_location} -C $BUILD_WORKSPACE_DIRECTORY/$1 --strip-components=2
+    tar -xzf {artifact_location} -C $BUILD_WORKSPACE_DIRECTORY/$1 --strip-components=1
 fi
 """
 


### PR DESCRIPTION
## What is the goal of this PR?

The updated `rules_pkg` (updated in https://github.com/vaticle/bazel-distribution/pull/382) packages `tar.gz` files without a leading `./` path. The artifact extractor therefore only needs to strip one layer from `tar.gz` files built by the `assemble_targz`, instead of two.

## What are the changes implemented in this PR?

Strip one layer of directories from `tar.gz` files while extracting TypeDB distributions.