### PR TITLE
Support architecture specific brew formulae

### DIFF
--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -33,18 +33,6 @@ def _deploy_brew_impl(ctx):
         else:
             substitution_files[key] = file.files.to_list()[0]
 
-    ctx.actions.expand_template(
-        template = ctx.file._deploy_brew_template,
-        output = ctx.outputs.deployment_script,
-        substitutions = {
-            '{brew_folder}': brew_formula_folder,
-            '{snapshot}' : ctx.attr.snapshot,
-            '{release}' : ctx.attr.release,
-            '{substitution_files}': json.encode({key: file.path for key, file in substitution_files.items()}),
-        },
-        is_executable = True,
-    )
-
     if not ctx.attr.version_file:
         version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
         version = ctx.var.get('version', '0.0.0')
@@ -56,6 +44,20 @@ def _deploy_brew_impl(ctx):
         )
     else:
         version_file = ctx.file.version_file
+
+    ctx.actions.expand_template(
+        template = ctx.file._deploy_brew_template,
+        output = ctx.outputs.deployment_script,
+        substitutions = {
+            '{brew_folder}': brew_formula_folder,
+            '{snapshot}' : ctx.attr.snapshot,
+            '{release}' : ctx.attr.release,
+            '{substitution_files}': json.encode({key: file.short_path for key, file in substitution_files.items()}),
+            '{formula_template}': ctx.file.formula.short_path,
+            '{version_file}': version_file.path,
+        },
+        is_executable = True,
+    )
 
     files = [
         ctx.file.formula,

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -32,17 +32,17 @@ import zipfile
 
 def get_distribution_urls_from_formula(content):
     return [
-        line[1]
+        line[1].strip('"')
         for line in map(lambda line: line.strip().split(), content.split('\n'))
-        if line[0] == 'url'
+        if len(line) == 2 and line[0] == 'url'
     ]
 
 
 def get_checksums_from_formula(content):
     return [
-        line[1]
+        line[1].strip('"')
         for line in map(lambda line: line.strip().split(), content.split('\n'))
-        if line[0] == 'sha256'
+        if len(line) == 2 and line[0] == 'sha256'
     ]
 
 
@@ -70,9 +70,9 @@ def expand_formula_template(formula_template: str, substitution_files: dict[str,
     for key, filename in substitution_files.items():
         if os.path.isfile(filename):
             with open(filename) as file:
-                expanded = expanded.replace(key, file.read())
+                expanded = expanded.replace(key, file.read().strip())
         else:
-            raise ValueError(f'Error - {file} substitution for key "{key}" not found (or not a regular file)')
+            raise ValueError(f'Error - {filename} substitution for key "{key}" not found (or not a regular file)')
     return expanded
 
 
@@ -87,10 +87,10 @@ substitution_files = json.loads('{substitution_files}')
 # configurations #
 git_username = os.getenv('DEPLOY_BREW_USERNAME')
 git_email = os.getenv('DEPLOY_BREW_EMAIL')
-formula_filename = os.path.basename(os.readlink('formula'))
-with open('formula') as formula_file:
+formula_filename = os.path.basename('{formula_template}')
+with open('{formula_template}') as formula_file:
     formula_template = formula_file.read()
-with open('VERSION') as version_file:
+with open('{version_file}') as version_file:
     version = version_file.read().strip()
 tap_type = sys.argv[1]
 

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -21,6 +21,7 @@
 
 from __future__ import print_function
 import hashlib
+import json
 import os
 import shutil
 import subprocess as sp
@@ -29,27 +30,25 @@ import tempfile
 import zipfile
 
 
-def get_distribution_url_from_formula(content):
-    url_line = next(iter(filter(lambda l: l.lstrip().startswith('url'), content.split('\n'))))
-    url = url_line.strip().split(' ')[1].replace('"', '')
-    return url
+def get_distribution_urls_from_formula(content):
+    return [
+        line[1]
+        for line in map(lambda line: line.strip().split(), content.split('\n'))
+        if line[0] == 'url'
+    ]
+
+
+def get_checksums_from_formula(content):
+    return [
+        line[1]
+        for line in map(lambda line: line.strip().split(), content.split('\n'))
+        if line[0] == 'sha256'
+    ]
 
 
 def url_with_credential(url, credential):
     scheme, rest = url.split('://')
     return scheme + '://"' + credential + '"@' + rest
-
-
-def get_checksum():
-    if os.path.isfile('checksum.sha256'):
-        with open('checksum.sha256') as checksum_file:
-            return checksum_file.read().strip().split(' ')[0]
-    elif 'DEPLOY_BREW_CHECKSUM' in os.environ:
-        return os.getenv('DEPLOY_BREW_CHECKSUM')
-    else:
-        raise ValueError('Error - checksum should either be defined '
-                         'in checksum.sha256 file or '
-                         '$DEPLOY_BREW_CHECKSUM env variable')
 
 
 def verify_zip_file(fn):
@@ -66,11 +65,24 @@ def verify_environment():
             sys.exit(1)
 
 
+def expand_formula_template(formula_template: str, substitution_files: dict[str, str]) -> str:
+    expanded = formula_template
+    for key, filename in substitution_files.items():
+        if os.path.isfile(filename):
+            with open(filename) as file:
+                expanded = expanded.replace(key, file.read())
+        else:
+            raise ValueError(f'Error - {file} substitution for key "{key}" not found (or not a regular file)')
+    return expanded
+
+
 if len(sys.argv) != 2:
     print('Error - needs an argument: <snapshot|release>')
     sys.exit(1)
 
 verify_environment()
+
+substitution_files = json.loads('{substitution_files}')
 
 # configurations #
 git_username = os.getenv('DEPLOY_BREW_USERNAME')
@@ -88,8 +100,6 @@ tap_repositories = {
 }
 tap_url = tap_repositories[tap_type]
 
-checksum_of_distribution_local = get_checksum()
-
 tap_localpath = tempfile.mkdtemp()
 try:
     print('Cloning brew tap: "{}"...'.format(tap_url))
@@ -97,28 +107,39 @@ try:
     sp.check_call(["git", "config", "user.email", git_email], cwd=tap_localpath)
     sp.check_call(["git", "config", "user.name", git_username], cwd=tap_localpath)
     sp.check_call(['mkdir', '-p', '{brew_folder}'], cwd=tap_localpath)
-    formula_content = formula_template.replace('{version}', version).replace('{sha256}', checksum_of_distribution_local)
-    distribution_url = get_distribution_url_from_formula(formula_content)
-    print('Attempting to match the checksums of local distribution and Github distribution from "{}"...'.format(distribution_url))
-    _, ext = os.path.splitext(distribution_url)
-    filename = 'distribution-github' + ext
-    sp.check_call([
-        'curl',
-        distribution_url,
-        '--fail',
-        '--location',
-        '--output',
-        filename
-    ])
-    if ext == '.zip':
-        verify_zip_file(filename)
-    checksum_of_distribution_github = hashlib.sha256(open(filename, 'rb').read()).hexdigest()
-    if checksum_of_distribution_local != checksum_of_distribution_github:
-        print('Error - unable to proceed with deploying to brew! The checksums do not match:')
-        print('- The checksum of local distribution: {}'.format(checksum_of_distribution_local))
-        print('- The checksum of Github distribution: {}'.format(checksum_of_distribution_github))
+
+    formula_content = expand_formula_template(formula_template.replace('{version}', version), substitution_files)
+    checksums = get_checksums_from_formula(formula_content)
+    distribution_urls = get_distribution_urls_from_formula(formula_content)
+
+    if len(checksums) != len(distribution_urls):
+        print('Error - unable to proceed with deploying to brew! The number of checksums does not match the number of URLs:')
+        print('- found {} checksums'.format(len(checksums)))
+        print('- found {} distribution URLs'.format(len(distribution_urls)))
         sys.exit(1)
-    print('The checksums matched. Proceeding with deploying to brew...')
+
+    for (checksum, distribution_url) in zip(checksums, distribution_urls):
+        print('Attempting to match the checksums of local distribution and Github distribution from "{}"...'.format(distribution_url))
+        _, ext = os.path.splitext(distribution_url)
+        filename = 'distribution-github' + ext
+        sp.check_call([
+            'curl',
+            distribution_url,
+            '--fail',
+            '--location',
+            '--output',
+            filename
+        ])
+        if ext == '.zip':
+            verify_zip_file(filename)
+        checksum_of_distribution_github = hashlib.sha256(open(filename, 'rb').read()).hexdigest()
+        if checksum != checksum_of_distribution_github:
+            print('Error - unable to proceed with deploying to brew! The checksums do not match:')
+            print('- The checksum of local distribution: {}'.format(checksum))
+            print('- The checksum of Github distribution: {}'.format(checksum_of_distribution_github))
+            sys.exit(1)
+    print('All checksums matched. Proceeding with deploying to brew...')
+
     with open(os.path.join(tap_localpath, '{brew_folder}', formula_filename), 'w') as f:
         f.write(formula_content)
     sp.check_call(['git', 'add', '.'], cwd=tap_localpath)

--- a/common/checksum/rules.bzl
+++ b/common/checksum/rules.bzl
@@ -21,7 +21,7 @@ def _checksum(ctx):
     ctx.actions.run_shell(
         inputs = [ctx.file.archive],
         outputs = [ctx.outputs.checksum_file],
-        command = 'mkdir tmp; unzip {} -d tmp; shasum -a 256 tmp/* > {}; rm -rf tmp/'.format(ctx.file.archive.path, ctx.outputs.checksum_file.path)
+        command = 'shasum -a 256 {} | cut -d" " -f1 > {}'.format(ctx.file.archive.path, ctx.outputs.checksum_file.path)
     )
 
 checksum = rule(

--- a/platform/BUILD
+++ b/platform/BUILD
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load(":constraints.bzl", "constraint_arm64", "constraint_x86_64", "constraint_linux", "constraint_mac", "constraint_windows",
+     "constraint_linux_arm64", "constraint_linux_x86_64", "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
+
+config_setting(
+    name = "is_linux",
+    constraint_values = constraint_linux,
+)
+
+config_setting(
+    name = "is_mac",
+    constraint_values = constraint_mac,
+)
+
+config_setting(
+    name = "is_windows",
+    constraint_values = constraint_windows,
+)
+
+config_setting(
+    name = "is_arm64",
+    constraint_values = constraint_arm64,
+)
+
+config_setting(
+    name = "is_x86_64",
+    constraint_values = constraint_x86_64,
+)
+
+config_setting(
+    name = "is_linux_arm64",
+    constraint_values = constraint_linux_arm64,
+)
+
+config_setting(
+    name = "is_linux_x86_64",
+    constraint_values = constraint_linux_x86_64,
+)
+
+config_setting(
+    name = "is_mac_arm64",
+    constraint_values = constraint_mac_arm64,
+)
+
+config_setting(
+    name = "is_mac_x86_64",
+    constraint_values = constraint_mac_x86_64,
+)
+
+config_setting(
+    name = "is_windows_x86_64",
+    constraint_values = constraint_win_x86_64,
+)
+
+platform(
+    name = "linux_arm64",
+    constraint_values = constraint_linux_arm64,
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = constraint_linux_x86_64,
+)
+
+platform(
+    name = "mac_arm64",
+    constraint_values = constraint_mac_arm64,
+)
+
+platform(
+    name = "mac_x86_64",
+    constraint_values = constraint_mac_x86_64,
+)
+
+platform(
+    name = "win_x86_64",
+    constraint_values = constraint_win_x86_64,
+)

--- a/platform/constraints.bzl
+++ b/platform/constraints.bzl
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+constraint_linux = [
+    "@platforms//os:linux",
+]
+
+constraint_mac = [
+    "@platforms//os:osx",
+]
+
+constraint_windows = [
+    "@platforms//os:windows",
+]
+
+constraint_arm64 = [
+    "@platforms//cpu:arm64",
+]
+
+constraint_x86_64 = [
+    "@platforms//cpu:x86_64",
+]
+
+constraint_linux_x86_64 = constraint_linux + constraint_x86_64
+constraint_linux_arm64 = constraint_linux + constraint_arm64
+constraint_mac_x86_64 = constraint_mac + constraint_x86_64
+constraint_mac_arm64 = constraint_mac + constraint_arm64
+constraint_win_x86_64 = constraint_windows + constraint_x86_64

--- a/platform/jvm/rules.bzl
+++ b/platform/jvm/rules.bzl
@@ -307,12 +307,13 @@ _assemble_zip_to_jvm_platform = rule(
 )
 
 
-# TODO: upgrade all to JDK17
-def native_jdk16():
+def native_jdk17():
     return select({
-        "@vaticle_dependencies//util/platform:is_mac": "@jdk16_mac//file",
-        "@vaticle_dependencies//util/platform:is_linux": "@jdk16_linux//file",
-        "@vaticle_dependencies//util/platform:is_windows": "@jdk16_windows//file",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@jdk17_linux_arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@jdk17_linux_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@jdk17_mac_arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@jdk17_mac_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@jdk17_windows_x86_64//file",
     })
 
 def assemble_jvm_platform(name,
@@ -328,7 +329,7 @@ def assemble_jvm_platform(name,
                           main_jar_path,
                           main_class,
                           icon = None,
-                          jdk = native_jdk16(),
+                          jdk = native_jdk17(),
                           additional_files = {},
                           verbose = False,
                           log_sensitive_data = False,
@@ -367,9 +368,9 @@ def assemble_jvm_platform(name,
         main_class = main_class,
         jdk = jdk,
         os = select({
-            "@vaticle_dependencies//util/platform:is_mac": "Mac",
-            "@vaticle_dependencies//util/platform:is_linux": "Linux",
-            "@vaticle_dependencies//util/platform:is_windows": "Windows",
+            "@vaticle_bazel_distribution//platform:is_mac": "Mac",
+            "@vaticle_bazel_distribution//platform:is_linux": "Linux",
+            "@vaticle_bazel_distribution//platform:is_windows": "Windows",
         }),
         verbose = verbose,
         log_sensitive_data = log_sensitive_data,
@@ -385,7 +386,7 @@ def assemble_jvm_platform(name,
         mac_deep_sign_jars_regex = mac_deep_sign_jars_regex,
         windows_menu_group = windows_menu_group,
         windows_wix_toolset = select({
-            "@vaticle_dependencies//util/platform:is_windows": windows_wix_toolset,
+            "@vaticle_bazel_distribution//platform:is_windows": windows_wix_toolset,
             "//conditions:default": None,
         }),
     )


### PR DESCRIPTION
## What is the goal of this PR?

We add limited support for multiple homebrew artifact URLs with corresponding checksums.

## What are the changes implemented in this PR?

- revert the checksum rule so that it computes the sha256 of the entire file rather than unzipping the file and checksumming its contents;
- move the platform configs from dependencies into here to break the circular dependency.