### PR TITLE
Assemble external workspace dependencies into Cargo dependencies

### DIFF
--- a/crates/CrateAssembler.kt
+++ b/crates/CrateAssembler.kt
@@ -64,9 +64,6 @@ class CrateAssembler : Callable<Unit> {
     @Option(names = ["--output-crate"], required = true)
     lateinit var outputCrateFile: File
 
-//    @Option(names = ["--output-metadata-json"], required = true)
-//    lateinit var outputMetadataFile: File
-
     @Option(names = ["--root"], required = true)
     lateinit var crateRoot: Path
 
@@ -121,7 +118,6 @@ class CrateAssembler : Callable<Unit> {
     override fun call() {
         val (externalDepsVersions: Map<String, String>, otherDepsVersions: Map<String, String>) = getDeps()
         writeCrateArchive(externalDepsVersions, otherDepsVersions)
-//        writeMetadataFile(externalDepsVersions, otherDepsVersions)
     }
 
     private fun getDeps(): Pair<MutableMap<String, String>, MutableMap<String, String>> {
@@ -276,58 +272,6 @@ class CrateAssembler : Callable<Unit> {
 
         return TomlWriter().writeToString(cargoToml.unmodifiable())
     }
-
-//    private fun writeMetadataFile(externalDepsVersions: MutableMap<String, String>, otherDepsVersions: MutableMap<String, String>) {
-//        outputMetadataFile.outputStream().use {
-//            it.write(constructMetadata(externalDepsVersions, otherDepsVersions).toByteArray(StandardCharsets.UTF_8))
-//        }
-//    }
-//
-//    private fun constructMetadata(): String {
-//        val features = JsonArray();
-//        return JsonObject().apply {
-//            set("name", name)
-//            set("vers", versionFile.readText())
-//            val depsArray = JsonArray()
-//            for (dep in depsList) {
-//                val (depName, depVer) = dep.split("=")
-//                val obj = JsonObject()
-//                obj.set("optional", false)
-//                obj.set("default_features", false)
-//                obj.set("name", depName)
-//                obj.set("features", JsonArray())
-//                obj.set("version_req", depVer)
-//                obj.set("target", Json.NULL)
-//                obj.set("kind", "normal")
-//                obj.set("registry", "")
-//                depsArray.add(obj)
-//            }
-//            set("deps", depsArray)
-//            set("features", JsonObject())
-//            set("authors", JsonArray().apply { authors.filter { it != "" }.forEach { add(it) } })
-//            set("description", description)
-//            if (documentation != null) {
-//                set("documentation", documentation)
-//            }
-//            set("homepage", homepage)
-//            readmeFile?.let {
-//                set("readme", readmeFile?.readText())
-//                set("readme_file", it.toPath().fileName.toString())
-//            } ?: run {
-//                set("readme", Json.NULL)
-//                set("readme_file", Json.NULL)
-//            }
-//            set("keywords", JsonArray().apply { keywords.filter { it != "" }.forEach { add(it) } })
-//            set("categories", JsonArray().apply { categories.filter { it != "" }.forEach { add(it) } })
-//            set("license", license)
-//            set("license_file", Json.NULL)
-//            set("repository", repository)
-//            // https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
-//            // as docs state all badges should go to README, so it's safe to keep it empty
-//            set("badges", JsonObject())
-//            set("links", Json.NULL)
-//        }.toString()
-//    }
 }
 
 fun main(args: Array<String>): Unit = exitProcess(CommandLine(CrateAssembler()).execute(*args))

--- a/crates/CrateAssembler.kt
+++ b/crates/CrateAssembler.kt
@@ -52,19 +52,22 @@ class CrateAssembler : Callable<Unit> {
 
     @Option(names = ["--deps"])
     lateinit var deps: String
-    private val depsList: Array<String>
-        get() = if (deps.isEmpty()) emptyArray() else deps.split(";").toTypedArray()
 
     @Option(names = ["--dep-features"])
     lateinit var depFeatures: String
     private val depFeaturesList: Array<String>
         get() = if (depFeatures.isEmpty()) emptyArray() else depFeatures.split(";").toTypedArray()
 
+    @Option(names = ["--dep-workspaces"])
+    lateinit var depWorkspaces: String
+    private val depWorkspaceList: Array<String>
+        get() = if (depWorkspaces.isEmpty()) emptyArray() else depWorkspaces.split(";").toTypedArray()
+
     @Option(names = ["--output-crate"], required = true)
     lateinit var outputCrateFile: File
 
-    @Option(names = ["--output-metadata-json"], required = true)
-    lateinit var outputMetadataFile: File
+//    @Option(names = ["--output-metadata-json"], required = true)
+//    lateinit var outputMetadataFile: File
 
     @Option(names = ["--root"], required = true)
     lateinit var crateRoot: Path
@@ -105,6 +108,9 @@ class CrateAssembler : Callable<Unit> {
     @Option(names = ["--universe-manifests"], split = ";")
     var universeManifests: Array<File> = arrayOf()
 
+    @Option(names = ["--workspace-refs-file"], required = false)
+    var workspaceRefsFile: File? = null;
+
     @Option(names = ["--readme-file"])
     var readmeFile: File? = null
 
@@ -112,11 +118,52 @@ class CrateAssembler : Callable<Unit> {
     lateinit var versionFile: File
 
     override fun call() {
-        writeCrateArchive()
-        writeMetadataFile()
+        val (externalDepsVersions: Map<String, String>, otherDepsVersions: Map<String, String>) = getDeps()
+        writeCrateArchive(externalDepsVersions, otherDepsVersions)
+//        writeMetadataFile(externalDepsVersions, otherDepsVersions)
     }
 
-    private fun writeCrateArchive() {
+    private fun getDeps(): Pair<MutableMap<String, String>, MutableMap<String, String>> {
+        val externalDepsVersions: MutableMap<String, String> = HashMap<String, String>().toMutableMap();
+        val otherDepsVersions: MutableMap<String, String> = HashMap<String, String>().toMutableMap();
+        val deps: Map<String, String> = if (deps.isEmpty()) {
+            emptyMap()
+        } else {
+            deps.split(";").associate { it.split("=").let { (dep, version) -> dep to version } }
+        };
+
+        if (workspaceRefsFile != null) {
+            val workspaceRefs = Json.parse(workspaceRefsFile?.readText()).asObject();
+            val bazelDepWorkspace = depWorkspaceList.associate { it.split("=").let { (dep, workspace) -> dep to workspace } }
+            for (entry in deps.entries) {
+                if (isExternalDep(entry.key, bazelDepWorkspace, workspaceRefs)) {
+                    externalDepsVersions[entry.key] = externalDepVersion(entry.key, bazelDepWorkspace, workspaceRefs);
+                } else {
+                    otherDepsVersions[entry.key] = entry.value
+                }
+            }
+        } else {
+            otherDepsVersions.putAll(deps);
+        }
+        return Pair(externalDepsVersions, otherDepsVersions)
+    }
+
+    private fun isExternalDep(dep: String, bazelDepWorkspace: Map<String, String>, workspaceRefs: JsonObject): Boolean {
+        val workspace = bazelDepWorkspace.get(dep)
+        return workspaceRefs.get("commits").asObject().get(workspace) != null ||
+                workspaceRefs.get("tags").asObject().get(workspace) != null;
+    }
+
+    private fun externalDepVersion(dep: String, bazelDepWorkspace: Map<String, String>, workspaceRefs: JsonObject): String {
+        val workspace = bazelDepWorkspace.get(dep)
+        val commitDep = workspaceRefs.get("commits").asObject().get(workspace)
+        if (commitDep != null) return commitDep.asString();
+        val tagDep = workspaceRefs.get("tags").asObject().get(workspace)
+        if (tagDep != null) return tagDep.asString();
+        throw IllegalStateException();
+    }
+
+    private fun writeCrateArchive(externalDepsVersions: Map<String, String>, otherDepsVersions: Map<String, String>) {
         val prefix = "$name-${versionFile.readText()}"
         outputCrateFile.outputStream().use { fos ->
             BufferedOutputStream(fos).use { bos ->
@@ -126,8 +173,8 @@ class CrateAssembler : Callable<Unit> {
                         val libraryRoot = crateRoot.toAbsolutePath().parent
                         srcsList.forEach { file ->
                             val sourceEntry = TarArchiveEntry(
-                                file,
-                                "$prefix/src/" + libraryRoot.relativize(file.toPath().toAbsolutePath()).toString()
+                                    file,
+                                    "$prefix/src/" + libraryRoot.relativize(file.toPath().toAbsolutePath()).toString()
                             )
                             tarOutputStream.putArchiveEntry(sourceEntry)
                             IOUtils.copy(file, tarOutputStream)
@@ -136,7 +183,7 @@ class CrateAssembler : Callable<Unit> {
 
                         val cargoToml = TarArchiveEntry("$prefix/Cargo.toml")
                         val crateRootPath = "src/" + libraryRoot.relativize(crateRoot.toAbsolutePath()).toString()
-                        val cargoTomlText = generateCargoToml(crateRootPath).toByteArray()
+                        val cargoTomlText = generateCargoToml(crateRootPath, externalDepsVersions, otherDepsVersions).toByteArray()
                         cargoToml.size = cargoTomlText.size.toLong()
                         tarOutputStream.putArchiveEntry(cargoToml)
 
@@ -148,7 +195,7 @@ class CrateAssembler : Callable<Unit> {
         }
     }
 
-    private fun generateCargoToml(crateRootPath: String): String {
+    private fun generateCargoToml(crateRootPath: String, externalDepsVersions: Map<String, String>, otherDepsVersions: Map<String, String>): String {
         val cargoToml = Config.inMemory()
         cargoToml.createSubConfig().apply {
             cargoToml.set<Config>("package", this)
@@ -174,87 +221,92 @@ class CrateAssembler : Callable<Unit> {
                     .getOrElse("dependencies", Config.inMemory()).entrySet().asSequence()
         }.associate { it.key to it.getValue<String>() }
 
-        val bazelDepFeatures = depFeaturesList.associate { it.split("=").let { (dep, feats) -> dep to feats } }
+        val externalDepFeatures = depFeaturesList.associate { it.split("=").let { (dep, feats) -> dep to feats } }
                 .mapValues { (_, feats) -> feats.split(",") }
 
         cargoToml.createSubConfig().apply {
             cargoToml.set<Config>("dependencies", this)
-            depsList.associate { it.split("=").let { (dep, ver) -> dep to ver } }.forEach { (dep, ver) ->
+            externalDepsVersions.forEach { (dep, version) ->
+                val depConfig = Config.inMemory()
+                set<Config>(dep, depConfig)
+                depConfig.set<String>("version", "=$version")
+                depConfig.set("features", externalDepFeatures.get(dep).orEmpty())
+            }
+
+            otherDepsVersions.forEach { (dep, version) ->
                 if (universeDeps.contains(dep))
                     set<String>(dep, universeDeps[dep])
-                else if (bazelDepFeatures.containsKey(dep)) {
-                    val depConfig = Config.inMemory()
-                    set<Config>(dep, depConfig)
-                    depConfig.set<String>("version", "=$ver")
-                    depConfig.set("features", bazelDepFeatures[dep])
-                } else
-                    set<String>(dep, "=$ver")
+                else
+                    set<String>(dep, "=$version")
             }
         }
 
         if (crateFeatures.isNotEmpty()) {
             cargoToml.createSubConfig().apply {
                 cargoToml.set<Config>("features", this)
-                crateFeatures.associate { it.split("=").let { items ->
-                    if (items.size == 2) items[0] to items[1].split(",")
-                    else items[0] to listOf()
-                } } .forEach { (feature, implied) -> set(feature, implied) }
+                crateFeatures.associate {
+                    it.split("=").let { items ->
+                        if (items.size == 2) items[0] to items[1].split(",")
+                        else items[0] to listOf()
+                    }
+                }.forEach { (feature, implied) -> set(feature, implied) }
             }
         }
 
         return TomlWriter().writeToString(cargoToml.unmodifiable())
     }
 
-    private fun writeMetadataFile() {
-        outputMetadataFile.outputStream().use {
-            it.write(constructMetadata().toByteArray(StandardCharsets.UTF_8))
-        }
-    }
-
-    private fun constructMetadata(): String {
-        return JsonObject().apply {
-            set("name", name)
-            set("vers", versionFile.readText())
-            val depsArray = JsonArray()
-            for (dep in depsList) {
-                val (depName, depVer) = dep.split("=")
-                val obj = JsonObject()
-                obj.set("optional", false)
-                obj.set("default_features", false)
-                obj.set("name", depName)
-                obj.set("features", JsonArray())
-                obj.set("version_req", depVer)
-                obj.set("target", Json.NULL)
-                obj.set("kind", "normal")
-                obj.set("registry", "")
-                depsArray.add(obj)
-            }
-            set("deps", depsArray)
-            set("features", JsonObject())
-            set("authors", JsonArray().apply { authors.filter { it != "" }.forEach { add(it) } })
-            set("description", description)
-            if (documentation != null) {
-                set("documentation", documentation)
-            }
-            set("homepage", homepage)
-            readmeFile?.let {
-                set("readme", readmeFile?.readText())
-                set("readme_file", it.toPath().fileName.toString())
-            } ?: run {
-                set("readme", Json.NULL)
-                set("readme_file", Json.NULL)
-            }
-            set("keywords", JsonArray().apply { keywords.filter { it != "" }.forEach { add(it) } })
-            set("categories", JsonArray().apply { categories.filter { it != "" }.forEach { add(it) } })
-            set("license", license)
-            set("license_file", Json.NULL)
-            set("repository", repository)
-            // https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
-            // as docs state all badges should go to README, so it's safe to keep it empty
-            set("badges", JsonObject())
-            set("links", Json.NULL)
-        }.toString()
-    }
+//    private fun writeMetadataFile(externalDepsVersions: MutableMap<String, String>, otherDepsVersions: MutableMap<String, String>) {
+//        outputMetadataFile.outputStream().use {
+//            it.write(constructMetadata(externalDepsVersions, otherDepsVersions).toByteArray(StandardCharsets.UTF_8))
+//        }
+//    }
+//
+//    private fun constructMetadata(): String {
+//        val features = JsonArray();
+//        return JsonObject().apply {
+//            set("name", name)
+//            set("vers", versionFile.readText())
+//            val depsArray = JsonArray()
+//            for (dep in depsList) {
+//                val (depName, depVer) = dep.split("=")
+//                val obj = JsonObject()
+//                obj.set("optional", false)
+//                obj.set("default_features", false)
+//                obj.set("name", depName)
+//                obj.set("features", JsonArray())
+//                obj.set("version_req", depVer)
+//                obj.set("target", Json.NULL)
+//                obj.set("kind", "normal")
+//                obj.set("registry", "")
+//                depsArray.add(obj)
+//            }
+//            set("deps", depsArray)
+//            set("features", JsonObject())
+//            set("authors", JsonArray().apply { authors.filter { it != "" }.forEach { add(it) } })
+//            set("description", description)
+//            if (documentation != null) {
+//                set("documentation", documentation)
+//            }
+//            set("homepage", homepage)
+//            readmeFile?.let {
+//                set("readme", readmeFile?.readText())
+//                set("readme_file", it.toPath().fileName.toString())
+//            } ?: run {
+//                set("readme", Json.NULL)
+//                set("readme_file", Json.NULL)
+//            }
+//            set("keywords", JsonArray().apply { keywords.filter { it != "" }.forEach { add(it) } })
+//            set("categories", JsonArray().apply { categories.filter { it != "" }.forEach { add(it) } })
+//            set("license", license)
+//            set("license_file", Json.NULL)
+//            set("repository", repository)
+//            // https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
+//            // as docs state all badges should go to README, so it's safe to keep it empty
+//            set("badges", JsonObject())
+//            set("links", Json.NULL)
+//        }.toString()
+//    }
 }
 
 fun main(args: Array<String>): Unit = exitProcess(CommandLine(CrateAssembler()).execute(*args))

--- a/crates/CrateAssembler.kt
+++ b/crates/CrateAssembler.kt
@@ -123,7 +123,7 @@ class CrateAssembler : Callable<Unit> {
     private fun getDeps(): Pair<MutableMap<String, String>, MutableMap<String, String>> {
         val externalDepsVersions: MutableMap<String, String> = HashMap<String, String>().toMutableMap();
         val otherDepsVersions: MutableMap<String, String> = HashMap<String, String>().toMutableMap();
-        val deps: Map<String, String> = if (deps.isEmpty()) {
+        val parsedDeps: Map<String, String> = if (deps.isEmpty()) {
             emptyMap()
         } else {
             deps.split(";").associate { it.split("=").let { (dep, version) -> dep to version } }
@@ -132,7 +132,7 @@ class CrateAssembler : Callable<Unit> {
         if (workspaceRefsFile != null) {
             val workspaceRefs = Json.parse(workspaceRefsFile?.readText()).asObject();
             val bazelDepWorkspace = depWorkspaceList.associate { it.split("=").let { (dep, workspace) -> dep to workspace } }
-            for (entry in deps.entries) {
+            for (entry in parsedDeps.entries) {
                 if (isExternalDep(entry.key, bazelDepWorkspace, workspaceRefs)) {
                     externalDepsVersions[entry.key] = externalDepVersion(entry.key, bazelDepWorkspace, workspaceRefs);
                 } else {
@@ -140,7 +140,7 @@ class CrateAssembler : Callable<Unit> {
                 }
             }
         } else {
-            otherDepsVersions.putAll(deps);
+            otherDepsVersions.putAll(parsedDeps);
         }
         return Pair(externalDepsVersions, otherDepsVersions)
     }

--- a/crates/CrateDeployer.kt
+++ b/crates/CrateDeployer.kt
@@ -46,9 +46,6 @@ class CrateDeployer : Callable<Unit> {
     @Option(names = ["--crate"], required = true)
     lateinit var crate: File
 
-    @Option(names = ["--metadata-json"], required = true)
-    lateinit var metadataJson: File
-
     @Option(names = ["--snapshot-repo"], required = true)
     lateinit var snapshotRepo: String
 
@@ -69,17 +66,9 @@ class CrateDeployer : Callable<Unit> {
     )
 
     override fun call() {
-        val metadataJsonContent = metadataJson.readBytes()
         val crateContent = crate.readBytes()
-        /*
-         * Cargo repository expects a single-part body containing both metadata in JSON
-         * and the actual crate in a tarball. Each part is prefixed with a
-         * 32-bit little-endian length identifier.
-         */
-        val payload = ByteBuffer.allocate(Int.SIZE_BYTES + metadataJsonContent.size + Int.SIZE_BYTES + crateContent.size)
+        val payload = ByteBuffer.allocate(Int.SIZE_BYTES + crateContent.size)
             .order(ByteOrder.LITTLE_ENDIAN)
-            .putInt(metadataJsonContent.size)
-            .put(metadataJsonContent)
             .putInt(crateContent.size)
             .put(crateContent)
             .array()

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -115,6 +115,10 @@ def _assemble_crate_impl(ctx):
         args.append("--readme-file")
         args.append(ctx.file.readme_file.path)
         inputs.append(ctx.file.readme_file)
+    if ctx.file.license_file:
+        args.append("--license-file")
+        args.append(ctx.file.license_file.path)
+        inputs.append(ctx.file.license_file)
     ctx.actions.run(
         inputs = inputs + ctx.attr.target[CrateInfo].srcs.to_list() + ctx.attr.target[CrateInfo].compile_data.to_list() + ctx.files.universe_manifests + [ctx.file.workspace_refs],
         outputs = [ctx.outputs.crate_package],#, ctx.outputs.metadata_json],
@@ -249,6 +253,11 @@ assemble_crate = rule(
             The license field contains the name of the software license that the package is released under.
             https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields
             """,
+        ),
+        "license_file": attr.label(
+            allow_single_file = True,
+            mandatory = False,
+            doc = "License file for the crate.",
         ),
         "repository": attr.string(
             mandatory = True,

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -93,7 +93,6 @@ def _assemble_crate_impl(ctx):
         "--deps", ";".join(["{}={}".format(k, v) for k, v in deps.items()]),
         "--dep-features", ";".join(["{}={}".format(k, v) for k, v in dep_features.items()]),
         "--dep-workspaces", ";".join(["{}={}".format(k, v) for k, v in deps_workspaces.items()]),
-        "--workspace-refs-file=" + ctx.file.workspace_refs.path,
     ]
     if ctx.attr.documentation != "":
         validate_url('documentation', ctx.attr.documentation)
@@ -117,6 +116,9 @@ def _assemble_crate_impl(ctx):
         args.append("--license-file")
         args.append(ctx.file.license_file.path)
         inputs.append(ctx.file.license_file)
+    if ctx.file.workspace_refs:
+        args.append("--workspace-refs-file=" + ctx.file.workspace_refs.path)
+        inputs.append(ctx.file.workspace_refs)
     ctx.actions.run(
         inputs = inputs + ctx.attr.target[CrateInfo].srcs.to_list() + ctx.attr.target[CrateInfo].compile_data.to_list() + ctx.files.universe_manifests + [ctx.file.workspace_refs],
         outputs = [ctx.outputs.crate_package],

--- a/crates/rules.bzl
+++ b/crates/rules.bzl
@@ -120,7 +120,7 @@ def _assemble_crate_impl(ctx):
         args.append("--workspace-refs-file=" + ctx.file.workspace_refs.path)
         inputs.append(ctx.file.workspace_refs)
     ctx.actions.run(
-        inputs = inputs + ctx.attr.target[CrateInfo].srcs.to_list() + ctx.attr.target[CrateInfo].compile_data.to_list() + ctx.files.universe_manifests + [ctx.file.workspace_refs],
+        inputs = inputs + ctx.attr.target[CrateInfo].srcs.to_list() + ctx.attr.target[CrateInfo].compile_data.to_list() + ctx.files.universe_manifests,
         outputs = [ctx.outputs.crate_package],
         executable = ctx.executable._crate_assembler_tool,
         arguments = args,

--- a/crates/templates/deploy.sh
+++ b/crates/templates/deploy.sh
@@ -20,6 +20,5 @@
 
 exec java -jar "$DEPLOYER_PATH" \
     --crate="$CRATE_PATH" \
-    --metadata-json="$METADATA_JSON_PATH" \
     --snapshot-repo="$SNAPSHOT_REPO" \
     --release-repo="$RELEASE_REPO" "$*"

--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -97,15 +97,15 @@ class PomGenerator : Callable<Unit> {
         return Triple(groupId, artifactId, version)
     }
 
-    fun version(originalVersion: String, version: String, workspace_refs: JsonObject): String {
+    fun version(originalVersion: String, version: String, workspaceRefs: JsonObject): String {
         if (originalVersion.equals("{pom_version}")) {
             return version
         }
-        val versionCommit = workspace_refs.get("commits").asObject().get(originalVersion)
+        val versionCommit = workspaceRefs.get("commits").asObject().get(originalVersion)
         if (versionCommit != null) {
             return versionCommit.asString()
         }
-        val tagCommit = workspace_refs.get("tags").asObject().get(originalVersion)
+        val tagCommit = workspaceRefs.get("tags").asObject().get(originalVersion)
         if (tagCommit != null) {
             return tagCommit.asString()
         }
@@ -165,7 +165,7 @@ class PomGenerator : Callable<Unit> {
         return scm
     }
 
-    fun dependencies(pom: Document, version: String, workspace_refs: JsonObject, dependencies: String): Element {
+    fun dependencies(pom: Document, version: String, workspaceRefs: JsonObject, dependencies: String): Element {
         val dependenciesElem = pom.createElement("dependencies")
         val coordinates = if (dependencies.isEmpty()) emptyArray() else dependencies.split(";").toTypedArray()
         for (dep in coordinates) {
@@ -177,7 +177,7 @@ class PomGenerator : Callable<Unit> {
             val dependencyArtifactId = pom.createElement("artifactId")
             dependencyArtifactId.appendChild(pom.createTextNode(depCoordinates.second))
             val dependencyVersion = pom.createElement("version")
-            dependencyVersion.appendChild(pom.createTextNode(version(depCoordinates.third, version, workspace_refs)))
+            dependencyVersion.appendChild(pom.createTextNode(version(depCoordinates.third, version, workspaceRefs)))
 
             dependencyElem.appendChild(dependencyGroupId)
             dependencyElem.appendChild(dependencyArtifactId)
@@ -196,7 +196,7 @@ class PomGenerator : Callable<Unit> {
 
     override fun call() {
         val version = versionFile.readText()
-        val workspace_refs = Json.parse(workspaceRefsFile.readText()).asObject()
+        val workspaceRefs = Json.parse(workspaceRefsFile.readText()).asObject()
 
         // Create an XML document for constructing the POM
         val pom = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()
@@ -253,7 +253,7 @@ class PomGenerator : Callable<Unit> {
         rootElement.appendChild(versionElem)
 
         // add dependency information
-        rootElement.appendChild(dependencies(pom, version, workspace_refs, dependencyCoordinates))
+        rootElement.appendChild(dependencies(pom, version, workspaceRefs, dependencyCoordinates))
 
         // write the final result
         outputDocumentToFile(pom)


### PR DESCRIPTION
## What is the goal of this PR?

Assembling a Rust crate failed to convert external bazel workspace dependencies into Crate depedencies using the external dependency's version, as specified by workspace refs. We now use workspace references to correctly convert external rust library dependencies into crate dependencies, with version specifiers.

In addition, we now package README and LICENSE files into the generate crate.

## What are the changes implemented in this PR?

* Experimental: delete `metadata` generation from Crate assembly, it may not be required
* Add workspace refs to crate assembly, which converts external bazel workspace dependencies into correctly versioned crate manifest dependencies
* add license and readme's into generated crate tarballs

