### PR TITLE
Refactor apt packaging to use new pkg_rules rules

### DIFF
--- a/apt/rules.bzl
+++ b/apt/rules.bzl
@@ -18,7 +18,7 @@
 #
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs", "pkg_mklink", "pkg_filegroup", "pkg_files")
 
 def _assemble_apt_version_file_impl(ctx):
     version = ctx.var.get('version', '0.0.0')
@@ -99,15 +99,40 @@ def assemble_apt(name,
             dirs = empty_dirs
         )
 
+        symlink_names = []
+        for link, target in symlinks.items():
+            print(link, target)
+            symlink_name = "_{}-{}".format(name, link.replace("/", "_").replace("\\", "_"))
+            symlink_names.append(symlink_name)
+            pkg_mklink(
+                name = symlink_name,
+                link_name = link,
+                target = target
+            )
+
+        archives_name = "_{}_archives".format(name)
+        pkg_tar(
+            name = archives_name,
+            package_dir = installation_dir,
+            deps = archives
+        )
+
+        files_name = "_{}_files".format(name)
+        pkg_files(
+            name = files_name,
+            prefix = installation_dir,
+            srcs = files.keys(),
+            renames = files,
+        )
+
         pkg_tar(
             name = tar_name,
             extension = "tar.gz",
-            deps = archives,
-            package_dir = installation_dir,
-            srcs = [empty_dirs_name],
-            files = files,
+#            package_dir = installation_dir,
+            srcs = [empty_dirs_name] + symlink_names + [files_name],
             mode = "0755",
-            symlinks = symlinks,
+            deps = [archives_name],
+#            symlinks = symlinks,
             modes = permissions,
         )
         deb_data = tar_name

--- a/apt/rules.bzl
+++ b/apt/rules.bzl
@@ -110,11 +110,11 @@ def assemble_apt(name,
                 target = target
             )
 
-        archives_name = "_{}_archives".format(name)
+        archives_merged_name = "_{}_archives".format(name)
         pkg_tar(
-            name = archives_name,
+            name = archives_merged_name,
             package_dir = installation_dir,
-            deps = archives
+            deps = archives # using deps instead of sources will merge tars into a single tar
         )
 
         files_name = "_{}_files".format(name)
@@ -128,11 +128,9 @@ def assemble_apt(name,
         pkg_tar(
             name = tar_name,
             extension = "tar.gz",
-#            package_dir = installation_dir,
             srcs = [empty_dirs_name] + symlink_names + [files_name],
             mode = "0755",
-            deps = [archives_name],
-#            symlinks = symlinks,
+            deps = [archives_merged_name],
             modes = permissions,
         )
         deb_data = tar_name


### PR DESCRIPTION
## What is the goal of this PR?

We refactor the `assemble_apt` rule to rely on new-style `pkg_rules` conventions: we add symlinks via `pkg_symlink`, and files via `pkg_files`, and archives to expand and embed via `pkg_tar`.

## What are the changes implemented in this PR?

* Refactor `assemble_apt` to use new packaging rules from `pkg_rules`