### PR TITLE
Update MacOS DMG signing and notarization process

### DIFF
--- a/platform/jvm/AppleCodeSigner.kt
+++ b/platform/jvm/AppleCodeSigner.kt
@@ -47,7 +47,7 @@ class AppleCodeSigner(private val shell: Shell, private val macEntitlements: Fil
     lateinit var certSubject: String
 
     fun init() {
-        deleteExistingKeychainIfPresent()
+        deleteKeychain()
         createKeychain()
         setDefaultKeychain()
         unlockKeychain()
@@ -57,7 +57,7 @@ class AppleCodeSigner(private val shell: Shell, private val macEntitlements: Fil
         initialised = true
     }
 
-    private fun deleteExistingKeychainIfPresent() {
+    fun deleteKeychain() {
         val keychainListInfo = shell.execute(listOf(SECURITY, LIST_KEYCHAINS)).outputString()
         if (KEYCHAIN_NAME in keychainListInfo) shell.execute(listOf(SECURITY, DELETE_KEYCHAIN, KEYCHAIN_NAME))
     }

--- a/platform/jvm/AppleCodeSigner.kt
+++ b/platform/jvm/AppleCodeSigner.kt
@@ -128,12 +128,6 @@ class AppleCodeSigner(private val shell: Shell, private val macEntitlements: Fil
         return subjectCommonName.value.toString()
     }
 
-    fun signAppImage(rootPath: Path, appName: String) {
-        signFile(rootPath.toFile())
-        signFile(rootPath.resolve(CONTENTS).resolve(RUNTIME).toFile())
-        signFile(rootPath.resolve(CONTENTS).resolve(MAC_OS).resolve(appName).toFile())
-    }
-
     fun signUnsignedNativeLibs(root: File) {
         // Some JARs contain unsigned `.jnilib` and `.dylib` files, which we can extract, sign and repackage
         for (jar in root.listFilesRecursively().filter {

--- a/platform/jvm/CommandLineParams.kt
+++ b/platform/jvm/CommandLineParams.kt
@@ -30,7 +30,7 @@ class CommandLineParams {
         const val APPLE_CODE_SIGNING_CERT_PASSWORD = "--apple_code_signing_cert_password"
         const val APPLE_ID = "--apple_id"
         const val APPLE_ID_PASSWORD = "--apple_id_password"
-        const val APPLE_TEAM_ID = "--apple-team-id"
+        const val APPLE_TEAM_ID = "--apple_team_id"
         const val CONFIG_PATH = "--config_path"
     }
 }

--- a/platform/jvm/CommandLineParams.kt
+++ b/platform/jvm/CommandLineParams.kt
@@ -6,7 +6,6 @@ import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_TEAM_ID
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.CONFIG_PATH
 import picocli.CommandLine
-import java.awt.GraphicsConfigTemplate
 import java.io.File
 
 class CommandLineParams {

--- a/platform/jvm/CommandLineParams.kt
+++ b/platform/jvm/CommandLineParams.kt
@@ -3,8 +3,10 @@ package com.vaticle.bazel.distribution.platform.jvm
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_CODE_SIGNING_CERT_PASSWORD
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_ID
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_ID_PASSWORD
+import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_TEAM_ID
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.CONFIG_PATH
 import picocli.CommandLine
+import java.awt.GraphicsConfigTemplate
 import java.io.File
 
 class CommandLineParams {
@@ -18,6 +20,9 @@ class CommandLineParams {
     @CommandLine.Option(names = [APPLE_ID_PASSWORD])
     lateinit var appleIDPassword: String
 
+    @CommandLine.Option(names = [APPLE_TEAM_ID])
+    lateinit var appleTeamID: String
+
     @CommandLine.Option(names = [APPLE_CODE_SIGNING_CERT_PASSWORD])
     lateinit var appleCodeSigningCertPassword: String
 
@@ -25,6 +30,7 @@ class CommandLineParams {
         const val APPLE_CODE_SIGNING_CERT_PASSWORD = "--apple_code_signing_cert_password"
         const val APPLE_ID = "--apple_id"
         const val APPLE_ID_PASSWORD = "--apple_id_password"
+        const val APPLE_TEAM_ID = "--apple-team-id"
         const val CONFIG_PATH = "--config_path"
     }
 }

--- a/platform/jvm/JVMPlatformAssembler.kt
+++ b/platform/jvm/JVMPlatformAssembler.kt
@@ -224,10 +224,10 @@ object JVMPlatformAssembler {
             }
 
             override fun afterPack() {
-                when (options.image.appleCodeSigning) {
+                when (val codeSigning = options.image.appleCodeSigning) {
                     null -> logger.debug { "Skipping notarizing step: Apple code signing is not enabled" }
                     else -> {
-                        MacAppNotarizer(dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg")).notarize()
+                        MacAppNotarizer(dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg")).notarize(codeSigning)
                         appleCodeSigner!!.deleteKeychain()
                     }
                 }

--- a/platform/jvm/JVMPlatformAssembler.kt
+++ b/platform/jvm/JVMPlatformAssembler.kt
@@ -224,15 +224,11 @@ object JVMPlatformAssembler {
             }
 
             override fun afterPack() {
-                when (val codeSigningOptions = options.image.appleCodeSigning) {
+                when (options.image.appleCodeSigning) {
                     null -> logger.debug { "Skipping notarizing step: Apple code signing is not enabled" }
                     else -> {
-                        val dmgFilename = "${options.image.filename}-$version.dmg"
-                        MacAppNotarizer(
-                            options = codeSigningOptions,
-                            dmgFilename = dmgFilename,
-                            dmgPath = Path.of(distDir.path, dmgFilename)
-                        ).notarize()
+                        MacAppNotarizer(dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg")).notarize()
+                        appleCodeSigner!!.deleteKeychain()
                     }
                 }
             }

--- a/platform/jvm/JVMPlatformAssembler.kt
+++ b/platform/jvm/JVMPlatformAssembler.kt
@@ -226,10 +226,12 @@ object JVMPlatformAssembler {
             }
 
             override fun afterPack() {
-                when (val codeSigning = options.image.appleCodeSigning) {
+                when (val codeSigningOptions = options.image.appleCodeSigning) {
                     null -> logger.debug { "Skipping notarizing step: Apple code signing is not enabled" }
                     else -> {
-                        MacAppNotarizer(dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg")).notarize(codeSigning)
+                        MacAppNotarizer(
+                            dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg")
+                        ).notarize(codeSigningOptions)
                         appleCodeSigner!!.deleteKeychain()
                     }
                 }

--- a/platform/jvm/JVMPlatformAssembler.kt
+++ b/platform/jvm/JVMPlatformAssembler.kt
@@ -7,6 +7,7 @@ import com.vaticle.bazel.distribution.common.OS.WINDOWS
 import com.vaticle.bazel.distribution.common.shell.Shell
 import com.vaticle.bazel.distribution.common.util.FileUtil.listFilesRecursively
 import com.vaticle.bazel.distribution.common.util.SystemUtil.currentOS
+import com.vaticle.bazel.distribution.platform.jvm.AppleCodeSigner.Companion.KEYCHAIN_NAME
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.InputFiles.Paths.JDK
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.InputFiles.Paths.SRC
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.InputFiles.Paths.WIX_TOOLSET
@@ -21,6 +22,8 @@ import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.Platform
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.LINUX_APP_CATEGORY
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.LINUX_MENU_GROUP
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.LINUX_SHORTCUT
+import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.MAC_SIGN
+import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.MAC_SIGNING_KEYCHAIN
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.MAIN_CLASS
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.MAIN_JAR
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.PlatformImageBuilder.JPackageArgs.NAME
@@ -218,7 +221,6 @@ object JVMPlatformAssembler {
                 // NOTE: the jpackage tool does have code signing options (--mac-sign, etc.), but they don't seem to
                 // work. We work around this by creating an app image, signing it, and repackaging it as a DMG.
                 super.pack()
-                signAppImageIfSigningEnabled()
                 convertPackageToDMG()
                 signDMGIfSigningEnabled()
             }
@@ -234,18 +236,15 @@ object JVMPlatformAssembler {
             }
 
             override fun packArgsPlatform(): List<String> {
-                return listOf(TYPE, "app-image") // license file (if exists) is added later, at the DMG creation stage
-            }
-
-            private fun signAppImageIfSigningEnabled() {
+                // license file (if exists) is added later, at the DMG creation stage
                 if (options.image.appleCodeSigningEnabled) {
-                    if (!appleCodeSigner!!.initialised) appleCodeSigner.init()
-                    appleCodeSigner.signAppImage(appImagePath, options.image.name)
+                    return listOf(
+                            TYPE, "app-image",
+                            MAC_SIGN,
+                            MAC_SIGNING_KEYCHAIN, KEYCHAIN_NAME,
+                    )
                 } else {
-                    logger.debug {
-                        "Apple code signing will not be performed because it disabled in the configuration " +
-                                " (it should only be enabled when distributing an image for use on other machines)"
-                    }
+                    return listOf(TYPE, "app-image")
                 }
             }
 
@@ -328,6 +327,8 @@ object JVMPlatformAssembler {
             const val LINUX_SHORTCUT = "--linux-shortcut"
             const val MAIN_CLASS = "--main-class"
             const val MAIN_JAR = "--main-jar"
+            const val MAC_SIGN = "--mac-sign"
+            const val MAC_SIGNING_KEYCHAIN = "--mac-signing-keychain"
             const val NAME = "--name"
             const val TYPE = "--type"
             const val VENDOR = "--vendor"

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -27,6 +27,7 @@ class MacAppNotarizer(private val dmgPath: Path) {
                 Shell.Command.arg(XCRUN), Shell.Command.arg(NOTARYTOOL), Shell.Command.arg(SUBMIT),
                 Shell.Command.arg(KEYCHAIN_PROFILE), Shell.Command.arg(KEYCHAIN_PASSWORD, printable = false),
                 Shell.Command.arg(WAIT), Shell.Command.arg(TIMEOUT), Shell.Command.arg(ONE_HOUR),
+                Shell.Command.arg(dmgPath.toString()),
         )
     }
 

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -4,11 +4,13 @@ import com.vaticle.bazel.distribution.common.shell.Shell
 import com.vaticle.bazel.distribution.platform.jvm.AppleCodeSigner.Companion.KEYCHAIN_PASSWORD
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.logger
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.shell
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.APPLE_ID
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.KEYCHAIN_PROFILE
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.NOTARYTOOL
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.ONE_HOUR
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.STAPLE
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.STAPLER
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.STORE_CREDENTIALS
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.SUBMIT
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.TIMEOUT
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.WAIT
@@ -16,10 +18,19 @@ import com.vaticle.bazel.distribution.platform.jvm.ShellArgs.Programs.XCRUN
 import java.nio.file.Path
 
 class MacAppNotarizer(private val dmgPath: Path) {
-    fun notarize() {
+    fun notarize(appleCodeSigning: Options.AppleCodeSigning) {
+        shell.execute(notarytoolKeystoreCommand(appleCodeSigning.appleID))
         val requestUUID = parseNotarizeResult(shell.execute(notarizeCommand()).outputString())
         logger.debug { "Notarization request UUID: $requestUUID" }
         markPackageAsApproved()
+    }
+
+    private fun notarytoolKeystoreCommand(appleID: String): Shell.Command {
+        return Shell.Command(
+                Shell.Command.arg(XCRUN), Shell.Command.arg(NOTARYTOOL),
+                Shell.Command.arg(STORE_CREDENTIALS), Shell.Command.arg(KEYCHAIN_PASSWORD, printable = false),
+                Shell.Command.arg(APPLE_ID), Shell.Command.arg(appleID)
+        )
     }
 
     private fun notarizeCommand(): Shell.Command {
@@ -42,13 +53,15 @@ class MacAppNotarizer(private val dmgPath: Path) {
     }
 
     private object Args {
+        const val APPLE_ID = "--apple-id"
         const val KEYCHAIN_PROFILE = "--keychain-profile"
         const val NOTARYTOOL = "notarytool"
+        const val ONE_HOUR = "1h"
         const val STAPLE = "staple"
         const val STAPLER = "stapler"
+        const val STORE_CREDENTIALS = "store-credentials"
         const val SUBMIT = "submit"
         const val TIMEOUT = "--timeout"
-        const val ONE_HOUR = "1h"
         const val WAIT = "--wait"
     }
 }

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -1,7 +1,6 @@
 package com.vaticle.bazel.distribution.platform.jvm
 
 import com.vaticle.bazel.distribution.common.shell.Shell
-import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.logger
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.shell
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.APPLE_ID
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.NOTARYTOOL
@@ -18,8 +17,7 @@ import java.nio.file.Path
 
 class MacAppNotarizer(private val dmgPath: Path) {
     fun notarize(appleCodeSigning: Options.AppleCodeSigning) {
-        val requestUUID = parseNotarizeResult(shell.execute(notarizeCommand(appleCodeSigning)).outputString())
-        logger.debug { "Notarization request UUID: $requestUUID" }
+        shell.execute(notarizeCommand(appleCodeSigning)).outputString()
         markPackageAsApproved()
     }
 
@@ -32,12 +30,6 @@ class MacAppNotarizer(private val dmgPath: Path) {
                 Shell.Command.arg(WAIT), Shell.Command.arg(TIMEOUT), Shell.Command.arg(ONE_HOUR),
                 Shell.Command.arg(dmgPath.toString()),
         )
-    }
-
-    private fun parseNotarizeResult(value: String): String {
-        return Regex("RequestUUID = ([a-z0-9\\-]{36})").find(value)?.groupValues?.get(1)
-                ?: throw IllegalStateException("Notarization failed: the response $value from " +
-                        "'xcrun altool --notarize-app' does not contain a valid RequestUUID")
     }
 
     private fun markPackageAsApproved() {

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -1,129 +1,53 @@
 package com.vaticle.bazel.distribution.platform.jvm
 
 import com.vaticle.bazel.distribution.common.shell.Shell
+import com.vaticle.bazel.distribution.platform.jvm.AppleCodeSigner.Companion.KEYCHAIN_PASSWORD
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.logger
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.shell
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.ALTOOL
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.FILE
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.NOTARIZATION_INFO
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.NOTARIZE_APP
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.PASSWORD
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.PRIMARY_BUNDLE_ID
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.KEYCHAIN_PROFILE
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.NOTARYTOOL
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.ONE_HOUR
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.STAPLE
 import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.STAPLER
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.USERNAME
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.NotarizationInfoResult.Status.APPROVED
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.NotarizationInfoResult.Status.PENDING
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.NotarizationInfoResult.Status.REJECTED
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.StatusPoller.LOG_FILE_URL
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.StatusPoller.MAX_RETRIES
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.StatusPoller.POLL_INTERVAL_MS
-import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.StatusPoller.STATUS_MESSAGE_PACKAGE_APPROVED
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.SUBMIT
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.TIMEOUT
+import com.vaticle.bazel.distribution.platform.jvm.MacAppNotarizer.Args.WAIT
 import com.vaticle.bazel.distribution.platform.jvm.ShellArgs.Programs.XCRUN
 import java.nio.file.Path
 
-class MacAppNotarizer(private val options: Options.AppleCodeSigning, private val dmgFilename: String, private val dmgPath: Path) {
+class MacAppNotarizer(private val dmgPath: Path) {
     fun notarize() {
         val requestUUID = parseNotarizeResult(shell.execute(notarizeCommand()).outputString())
         logger.debug { "Notarization request UUID: $requestUUID" }
-        waitForPackageApproval(requestUUID)
         markPackageAsApproved()
     }
 
     private fun notarizeCommand(): Shell.Command {
-        // TODO: xcrun altool --notarize-app is deprecated in Xcode 13: see
-        //       https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow?preferredLanguage=occ
         return Shell.Command(
-            Shell.Command.arg(XCRUN), Shell.Command.arg(ALTOOL), Shell.Command.arg(NOTARIZE_APP),
-            Shell.Command.arg(PRIMARY_BUNDLE_ID), Shell.Command.arg(options.macAppID),
-            Shell.Command.arg(USERNAME), Shell.Command.arg(options.appleID, printable = false),
-            Shell.Command.arg(PASSWORD), Shell.Command.arg(options.appleIDPassword, printable = false),
-            Shell.Command.arg(FILE), Shell.Command.arg(dmgPath.toString())
+                Shell.Command.arg(XCRUN), Shell.Command.arg(NOTARYTOOL), Shell.Command.arg(SUBMIT),
+                Shell.Command.arg(KEYCHAIN_PROFILE), Shell.Command.arg(KEYCHAIN_PASSWORD, printable = false),
+                Shell.Command.arg(WAIT), Shell.Command.arg(TIMEOUT), Shell.Command.arg(ONE_HOUR),
         )
     }
 
     private fun parseNotarizeResult(value: String): String {
         return Regex("RequestUUID = ([a-z0-9\\-]{36})").find(value)?.groupValues?.get(1)
-            ?: throw IllegalStateException("Notarization failed: the response $value from " +
-                    "'xcrun altool --notarize-app' does not contain a valid RequestUUID")
-    }
-
-    private fun waitForPackageApproval(requestUUID: String) {
-        var retries = 0
-        while (retries < MAX_RETRIES) {
-            Thread.sleep(POLL_INTERVAL_MS)
-            val notarizeResult = NotarizationInfoResult.of(
-                shell.execute(notarizationInfoCommand(requestUUID)).outputString()
-            )
-            when (notarizeResult.status) {
-                PENDING -> retries++
-                APPROVED -> {
-                    logger.debug { "$dmgFilename was APPROVED by the Apple notarization service" }
-                    return
-                }
-                REJECTED -> {
-                    throw IllegalStateException("$dmgFilename was REJECTED by the Apple notarization service\n${notarizeResult.rawText}")
-                }
-            }
-        }
-        throw IllegalStateException("Timed out while waiting for $dmgFilename to be scanned by the Apple notarization service; the bundle is still in PENDING status (RequestUUID = $requestUUID)")
-    }
-
-    private fun notarizationInfoCommand(requestUUID: String): Shell.Command {
-        return Shell.Command(
-            Shell.Command.arg(XCRUN), Shell.Command.arg(ALTOOL), Shell.Command.arg(NOTARIZATION_INFO),
-            Shell.Command.arg(requestUUID),
-            Shell.Command.arg(USERNAME), Shell.Command.arg(options.appleID, printable = false),
-            Shell.Command.arg(PASSWORD), Shell.Command.arg(options.appleIDPassword, printable = false)
-        )
+                ?: throw IllegalStateException("Notarization failed: the response $value from " +
+                        "'xcrun altool --notarize-app' does not contain a valid RequestUUID")
     }
 
     private fun markPackageAsApproved() {
         shell.execute(listOf(XCRUN, STAPLER, STAPLE, dmgPath.toString()))
     }
 
-    private data class NotarizationInfoResult(val status: Status, val rawText: String) {
-        enum class Status {
-            PENDING,
-            APPROVED,
-            REJECTED
-        }
-
-        companion object {
-            fun of(info: String): NotarizationInfoResult {
-                return when {
-                    STATUS_MESSAGE_PACKAGE_APPROVED in info -> {
-                        NotarizationInfoResult(status = APPROVED, rawText = info)
-                    }
-                    LOG_FILE_URL in info -> {
-                        // Apple log file takes time to build, so it's possible to see "Package Declined" before a
-                        // LogFileURL is available. It's useful to read the log file, so we wait for it to be generated.
-                        NotarizationInfoResult(status = REJECTED, rawText = info)
-                    }
-                    else -> {
-                        NotarizationInfoResult(status = PENDING, rawText = info)
-                    }
-                }
-            }
-        }
-    }
-
     private object Args {
-        const val ALTOOL = "altool"
-        const val FILE = "--file"
-        const val NOTARIZATION_INFO = "--notarization-info"
-        const val NOTARIZE_APP = "--notarize-app"
-        const val PASSWORD = "--password"
-        const val PRIMARY_BUNDLE_ID = "--primary-bundle-id"
+        const val KEYCHAIN_PROFILE = "--keychain-profile"
+        const val NOTARYTOOL = "notarytool"
         const val STAPLE = "staple"
         const val STAPLER = "stapler"
-        const val USERNAME = "--username"
-    }
-
-    private object StatusPoller {
-        const val LOG_FILE_URL = "LogFileURL"
-        const val MAX_RETRIES = 30
-        const val POLL_INTERVAL_MS = 30000L
-        const val STATUS_MESSAGE_PACKAGE_APPROVED = "Status Message: Package Approved"
+        const val SUBMIT = "submit"
+        const val TIMEOUT = "--timeout"
+        const val ONE_HOUR = "1h"
+        const val WAIT = "--wait"
     }
 }

--- a/platform/jvm/Options.kt
+++ b/platform/jvm/Options.kt
@@ -29,6 +29,7 @@ import com.vaticle.bazel.distribution.common.util.PropertiesUtil.requireString
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_CODE_SIGNING_CERT_PASSWORD
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_ID
 import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_ID_PASSWORD
+import com.vaticle.bazel.distribution.platform.jvm.CommandLineParams.Keys.APPLE_TEAM_ID
 import com.vaticle.bazel.distribution.platform.jvm.JVMPlatformAssembler.logger
 import com.vaticle.bazel.distribution.platform.jvm.Options.Keys.APPLE_CODE_SIGN
 import com.vaticle.bazel.distribution.platform.jvm.Options.Keys.APPLE_CODE_SIGNING_CERT_PATH
@@ -163,7 +164,8 @@ data class Options(val logging: Logging, val input: Input, val image: Image, val
     }
 
     data class AppleCodeSigning(
-        val appleID: String, val appleIDPassword: String, val cert: File, val certPassword: String,
+        val appleID: String, val appleIDPassword: String, val appleTeamID: String,
+        val cert: File, val certPassword: String,
         val macAppID: String, val deepSignJarsRegex: Regex?
     ) {
         val signNativeLibsInDeps: Boolean = deepSignJarsRegex != null
@@ -173,6 +175,7 @@ data class Options(val logging: Logging, val input: Input, val image: Image, val
                 AppleCodeSigning(
                     appleID = require(APPLE_ID, appleID),
                     appleIDPassword = require(APPLE_ID_PASSWORD, appleIDPassword),
+                    appleTeamID = require(APPLE_TEAM_ID, appleTeamID),
                     cert = File(props.requireString(APPLE_CODE_SIGNING_CERT_PATH)),
                     certPassword = require(APPLE_CODE_SIGNING_CERT_PASSWORD, appleCodeSigningCertPassword),
                     macAppID = props.requireString(MAC_APP_ID),

--- a/platform/jvm/rules.bzl
+++ b/platform/jvm/rules.bzl
@@ -175,12 +175,14 @@ windowsWiXToolsetPath: {}
     if "APPLE_CODE_SIGN" in ctx.var and ctx.var["APPLE_CODE_SIGN"] == "yes":
         _require_apple_code_signing_var(ctx, "APPLE_ID")
         _require_apple_code_signing_var(ctx, "APPLE_ID_PASSWORD")
+        _require_apple_code_signing_var(ctx, "APPLE_TEAM_ID")
         _require_apple_code_signing_var(ctx, "APPLE_CODE_SIGNING_CERT_PASSWORD")
 
         arguments = [
             config_path_arg,
             "--apple_id={}".format(ctx.var["APPLE_ID"]),
             "--apple_id_password={}".format(ctx.var["APPLE_ID_PASSWORD"]),
+            "--apple_team_id={}".format(ctx.var["APPLE_TEAM_ID"]),
             "--apple_code_signing_cert_password={}".format(ctx.var["APPLE_CODE_SIGNING_CERT_PASSWORD"])
         ]
     else:

--- a/platform/jvm/rules.bzl
+++ b/platform/jvm/rules.bzl
@@ -309,13 +309,13 @@ _assemble_zip_to_jvm_platform = rule(
 )
 
 
-def native_jdk17():
+def native_jdk21():
     return select({
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@jdk17_linux_arm64//file",
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@jdk17_linux_x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@jdk17_mac_arm64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@jdk17_mac_x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@jdk17_windows_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@jdk21_linux_arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@jdk21_linux_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@jdk21_mac_arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@jdk21_mac_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@jdk21_windows_x86_64//file",
     })
 
 def assemble_jvm_platform(name,
@@ -331,7 +331,7 @@ def assemble_jvm_platform(name,
                           main_jar_path,
                           main_class,
                           icon = None,
-                          jdk = native_jdk17(),
+                          jdk = native_jdk21(),
                           additional_files = {},
                           verbose = False,
                           log_sensitive_data = False,

--- a/platform/jvm/rules.bzl
+++ b/platform/jvm/rules.bzl
@@ -309,13 +309,13 @@ _assemble_zip_to_jvm_platform = rule(
 )
 
 
-def native_jdk21():
+def native_jdk17():
     return select({
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@jdk21_linux_arm64//file",
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@jdk21_linux_x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@jdk21_mac_arm64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@jdk21_mac_x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@jdk21_windows_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@jdk17_linux_arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@jdk17_linux_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@jdk17_mac_arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@jdk17_mac_x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@jdk17_windows_x86_64//file",
     })
 
 def assemble_jvm_platform(name,
@@ -331,7 +331,7 @@ def assemble_jvm_platform(name,
                           main_jar_path,
                           main_class,
                           icon = None,
-                          jdk = native_jdk21(),
+                          jdk = native_jdk17(),
                           additional_files = {},
                           verbose = False,
                           log_sensitive_data = False,


### PR DESCRIPTION
## What is the goal of this PR?

We switch to using `jpackage` to sign the AppImage rather than signing the files manually. We also switch from `altool`, which is now deprecated for notarization, to `notarytool`. 

## What are the changes implemented in this PR?

JVM17 `jpackage`, unlike before, always attempts to sign `Home/runtime` when assembling an AppImage. In the absence of credentials, it uses ad-hoc signing, in the process stripping the Oracle signatures from the JVM runtime files, which causes the notary to reject the submitted app. This behaviour does not appear to be configurable outside of being able to provide credentials to the signing process, which we now do instead of running `codesign` ourselves.

The `altool` deprecation appears to have been a red herring, but upgrading to `notarytool` was past due regardless.