### PR TITLE
targz_edit: modify contents of targz

### DIFF
--- a/common/targz/rules.bzl
+++ b/common/targz/rules.bzl
@@ -95,3 +95,16 @@ def assemble_targz(name,
         visibility = visibility,
         tags = tags,
     )
+
+def targz_edit(name, src, strip_components = 0, **kwargs):
+    extra_args = ["--strip-components", str(strip_components)]
+    native.genrule(
+        name = name,
+        outs = [name],
+        srcs = [src],
+        cmd_bash =
+            "mkdir -p tmpdir &&" +
+            "tar -xzf $< -C tmpdir {} &&".format(" ".join(extra_args)) +
+            "tar -czf $@ -C tmpdir --strip-components=1 .",
+        **kwargs
+    )


### PR DESCRIPTION
## What is the goal of this PR?

We introduce `targz_edit()`, a rule that allows us to modify a targz. Currently, this rule only supports the `strip_components` argument.
