### PR TITLE
Release candidate support

### DIFF
--- a/crates/CrateAssembler.kt
+++ b/crates/CrateAssembler.kt
@@ -164,10 +164,19 @@ class CrateAssembler : Callable<Unit> {
     private fun externalDepVersion(dep: String, bazelDepWorkspace: Map<String, String>, workspaceRefs: JsonObject): String {
         val workspace = bazelDepWorkspace.get(dep)
         val commitDep = workspaceRefs.get("commits").asObject().get(workspace)
-        if (commitDep != null) return commitDep.asString();
+        if (commitDep != null) return commitToVersion(commitDep.asString());
         val tagDep = workspaceRefs.get("tags").asObject().get(workspace)
-        if (tagDep != null) return tagDep.asString();
+        if (tagDep != null) return tagToVersion(tagDep.asString());
         throw IllegalStateException();
+    }
+
+    private fun commitToVersion(commit: String): String {
+        return "0.0.0-${commit}"
+    }
+
+    private fun tagToVersion(tag: String): String {
+        if (tag.contains("rc")) return tag.replace(Regex("-?rc"), "-rc")
+        else return tag
     }
 
     private fun writeCrateArchive(config: UnmodifiableConfig) {
@@ -226,7 +235,7 @@ class CrateAssembler : Callable<Unit> {
             cargoToml.set<Config>("package", this)
             set<String>("name", name)
             set<String>("edition", edition)
-            set<String>("version", versionFile.readText())
+            set<String>("version", tagToVersion(versionFile.readText()))
             set<Array<String>>("authors", authors.filter { it != "" })
             set<String>("homepage", homepage)
             set<String>("repository", repository)

--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -102,13 +102,9 @@ class PomGenerator : Callable<Unit> {
             return version
         }
         val versionCommit = workspaceRefs.get("commits").asObject().get(originalVersion)
-        if (versionCommit != null) {
-            return versionCommit.asString()
-        }
+        if (versionCommit != null) return commitToVersion(versionCommit.asString())
         val tagCommit = workspaceRefs.get("tags").asObject().get(originalVersion)
-        if (tagCommit != null) {
-            return tagCommit.asString()
-        }
+        if (tagCommit != null) return tagToVersion(tagCommit.asString())
         return originalVersion
     }
 
@@ -195,7 +191,7 @@ class PomGenerator : Callable<Unit> {
     }
 
     override fun call() {
-        val version = versionFile.readText()
+        val version = tagToVersion(versionFile.readText())
         val workspaceRefs = Json.parse(workspaceRefsFile.readText()).asObject()
 
         // Create an XML document for constructing the POM
@@ -257,6 +253,15 @@ class PomGenerator : Callable<Unit> {
 
         // write the final result
         outputDocumentToFile(pom)
+    }
+
+    private fun commitToVersion(commit: String): String {
+        return "0.0.0-$commit"
+    }
+
+    private fun tagToVersion(tag: String): String {
+        if (tag.contains("rc")) return tag.replace(Regex("-?rc"), "-rc")
+        else return tag
     }
 }
 

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -38,6 +38,10 @@ def _generate_version_file(ctx):
         version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
         version = ctx.var.get("version", "0.0.0")
 
+        if len(version) == 40:
+            # this is a commit SHA, most likely
+            version = "0.0.0-{}".format(version)
+
         ctx.actions.run_shell(
             inputs = [],
             outputs = [version_file],

--- a/npm/assemble/rules.bzl
+++ b/npm/assemble/rules.bzl
@@ -28,6 +28,8 @@ def _assemble_npm_impl(ctx):
         if len(version) == 40:
             # this is a commit SHA, most likely
             version = "0.0.0-{}".format(version)
+        elif 'rc' in version and '-rc' not in version:
+            version = version.replace('rc', '-rc')
 
         ctx.actions.run_shell(
             inputs = [],

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -137,6 +137,8 @@ def _assemble_pip_impl(ctx):
         if len(version) == 40:
             # this is a commit SHA, most likely
             version = "0.0.0+{}".format(version)
+        elif '-rc' in version:
+            version = version.replace('-rc', 'rc')
 
         ctx.actions.run_shell(
             inputs = [],


### PR DESCRIPTION
## What is the goal of this PR?

We add support for repository-specific prerelease versioning, currently limited to "rc" (release candidate).

This change ensures the following format:

- `{version}-rc{number}` in maven packages, npm packages, and crates (following [SemVer 2.0.0 spec](https://semver.org/spec/v2.0.0.html));
- `{version}rc{number}` in pip packages (see [Python Packagin User Guide :: Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers))

## What are the changes implemented in this PR?

Drive-by: ensure semver compatibility for snapshot releases in crates and maven by prepending `0.0.0-` to the git commit SHA.