### PR TITLE
Fix maven pre-deploy snapshot version validation: require SemVer-SHA

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -82,7 +82,7 @@ if version is None or len(version.text) == 0:
 version = version.text
 
 snapshot = 'snapshot'
-version_snapshot_regex = '^[0-9|a-f|A-F]{40}$|.*-SNAPSHOT$'
+version_snapshot_regex = '^[0-9]+.[0-9]+.[0-9]+-[0-9|a-f|A-F]{40}$|.*-SNAPSHOT$'
 release = 'release'
 version_release_regex = '^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)*$'
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix regression introduced in #397: prepending `0.0.0-` to the commit SHA for snapshot assembly broke the validation in the deployment script, which expects either bare SHA or any string ending with `-SNAPSHOT`. We now require either a major.minor.patch version with the SHA at the end, or any string ending with `-SNAPSHOT`.