### PR TITLE
Add unizp_file utility rule

### DIFF
--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -24,7 +24,7 @@ load("@vaticle_bazel_distribution//common/java_deps:rules.bzl", _java_deps = "ja
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", _tgz2zip = "tgz2zip")
 load("@vaticle_bazel_distribution//common/targz:rules.bzl", _assemble_targz = "assemble_targz")
 load("@vaticle_bazel_distribution//common/workspace_refs:rules.bzl", _workspace_refs = "workspace_refs")
-load("@vaticle_bazel_distribution//common/zip:rules.bzl", _assemble_zip = "assemble_zip", _unzip = "unzip")
+load("@vaticle_bazel_distribution//common/zip:rules.bzl", _assemble_zip = "assemble_zip", _unzip_file = "unzip_file")
 load("@vaticle_bazel_distribution//common/rename:rules.bzl", _file_rename = "file_rename")
 
 assemble_targz = _assemble_targz
@@ -35,5 +35,5 @@ file_rename = _file_rename
 generate_json_config = _generate_json_config
 java_deps = _java_deps
 tgz2zip = _tgz2zip
-unzip = _unzip
+unzip_file = _unzip_file
 workspace_refs = _workspace_refs

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -24,7 +24,7 @@ load("@vaticle_bazel_distribution//common/java_deps:rules.bzl", _java_deps = "ja
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", _tgz2zip = "tgz2zip")
 load("@vaticle_bazel_distribution//common/targz:rules.bzl", _assemble_targz = "assemble_targz")
 load("@vaticle_bazel_distribution//common/workspace_refs:rules.bzl", _workspace_refs = "workspace_refs")
-load("@vaticle_bazel_distribution//common/zip:rules.bzl", _assemble_zip = "assemble_zip")
+load("@vaticle_bazel_distribution//common/zip:rules.bzl", _assemble_zip = "assemble_zip", _unzip = "unzip")
 load("@vaticle_bazel_distribution//common/rename:rules.bzl", _file_rename = "file_rename")
 
 assemble_targz = _assemble_targz
@@ -35,4 +35,5 @@ file_rename = _file_rename
 generate_json_config = _generate_json_config
 java_deps = _java_deps
 tgz2zip = _tgz2zip
+unzip = _unzip
 workspace_refs = _workspace_refs

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -60,3 +60,13 @@ def assemble_zip(
         visibility = visibility,
         tags = tags,
     )
+
+def unzip(name, target, outs, **kwargs):
+    native.genrule(
+        name = name,
+        srcs = [target],
+        outs = outs,
+        tools = ["@bazel_tools//tools/zip:zipper"],
+        cmd = "$(location @bazel_tools//tools/zip:zipper) x $< -d $(@D)",
+        **kwargs
+    )

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -61,19 +61,20 @@ def assemble_zip(
         tags = tags,
     )
 
-def unzip(name, target, outs, **kwargs):
-    """Unzip an archive
+def unzip_file(name, target, output, **kwargs):
+    """Unzip a single-file archive
 
     Args:
-        name: A unique name for this target.
-        target: A single input .zip archive
-        outs: List of files to be extracted from the archive.
+        name: unique name for this target
+        target: single input .zip archive
+        output: name for the unzipped file
     """
     native.genrule(
         name = name,
         srcs = [target],
-        outs = outs,
+        outs = [output],
         tools = ["@bazel_tools//tools/zip:zipper"],
-        cmd = "$(location @bazel_tools//tools/zip:zipper) x $< -d $(@D)",
+        cmd_bash = "mkdir -p $(@D)/tmp && $(location @bazel_tools//tools/zip:zipper) x $< -d $(@D)/tmp && mv $(@D)/tmp/* $@",
+        cmd_bat = "MD $(@D)\\tmp && $(location @bazel_tools//tools/zip:zipper) x $< -d $(@D)\\tmp && MOVE $(@D)\\tmp\\* $@",
         **kwargs
     )

--- a/common/zip/rules.bzl
+++ b/common/zip/rules.bzl
@@ -62,6 +62,13 @@ def assemble_zip(
     )
 
 def unzip(name, target, outs, **kwargs):
+    """Unzip an archive
+
+    Args:
+        name: A unique name for this target.
+        target: A single input .zip archive
+        outs: List of files to be extracted from the archive.
+    """
     native.genrule(
         name = name,
         srcs = [target],


### PR DESCRIPTION
## What is the goal of this PR?

We add a new common utility rule that allows the user to unzip a zip archive containing a single file and give that file a new name.