### PR TITLE
targz_edit: add support for glob exclusion patterns

### DIFF
--- a/common/targz/rules.bzl
+++ b/common/targz/rules.bzl
@@ -96,8 +96,14 @@ def assemble_targz(name,
         tags = tags,
     )
 
-def targz_edit(name, src, strip_components = 0, **kwargs):
-    extra_args = ["--strip-components", str(strip_components)]
+def targz_edit(name, src, strip_components = 0, exclude_globs = None, **kwargs):
+    extra_args = []
+    if strip_components > 0:
+        extra_args.extend(["--strip-components", str(strip_components)])
+    if exclude_globs:
+        for exclude_pattern in exclude_globs:
+            extra_args.extend(["--exclude", exclude_pattern])
+
     native.genrule(
         name = name,
         outs = [name],

--- a/common/targz/rules.bzl
+++ b/common/targz/rules.bzl
@@ -96,7 +96,20 @@ def assemble_targz(name,
         tags = tags,
     )
 
-def targz_edit(name, src, strip_components = 0, exclude_globs = None, **kwargs):
+def targz_edit(name, src, strip_components = 0, exclude_globs = [], **kwargs):
+    """Edit distribution archive (.tar.gz)
+
+    Args:
+        name: A unique name for this target, serves as the output filename.
+        src: The .tar.gz archive to edit.
+        strip_components (int): argument to tar -xz --strip-components
+             Remove the specified number of leading path elements.  Pathnames
+             with fewer elements will be silently skipped.  Note that the
+             pathname is edited after checking inclusion/exclusion patterns but
+             before security checks.
+        exclude_globs (list of strs): arguments to tar -xz --exclude
+             Do not process files or directories that match the specified pattern.
+    """
     extra_args = []
     if strip_components > 0:
         extra_args.extend(["--strip-components", str(strip_components)])


### PR DESCRIPTION
## What is the goal of this PR?

We add the options to exclude files and directories that match glob patterns from the edited .tar.gz archive.