### PR TITLE
Artifact deployment: use version_file, fix version validation

### DIFF
--- a/artifact/rules.bzl
+++ b/artifact/rules.bzl
@@ -22,15 +22,18 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def _deploy_artifact_impl(ctx):
     _deploy_script = ctx.actions.declare_file(ctx.attr.deploy_script_name)
 
-    version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
-    version = ctx.var.get('version', '0.0.0')
+    if ctx.attr.version_file:
+        version_file = ctx.file.version_file
+    else:
+        version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
+        version = ctx.var.get('version', '0.0.0')
 
-    ctx.actions.run_shell(
-        inputs = [],
-        outputs = [version_file],
-        command = "echo {} > {}".format(version, version_file.path),
-    )
-    
+        ctx.actions.run_shell(
+            inputs = [],
+            outputs = [version_file],
+            command = "echo {} > {}".format(version, version_file.path),
+        )
+        
     ctx.actions.expand_template(
         template = ctx.file._deploy_script_template,
         output = _deploy_script,

--- a/artifact/templates/deploy.py
+++ b/artifact/templates/deploy.py
@@ -50,7 +50,7 @@ if not password:
 version = open("{version_file}", "r").read().strip()
 
 snapshot = 'snapshot'
-version_snapshot_regex = '^[0-9|a-f|A-F]{40}$'
+version_snapshot_regex = '^.*[0-9a-fA-F]{40}$'
 release = 'release'
 version_release_regex = '^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)*$'
 


### PR DESCRIPTION
## What is the goal of this PR?

We fix two issues in artifact deployment rules:
1. The `version_file` argument was ignored in favor of the `version` environment variable. The behavior is now in line with the rest of rulesi n this repository.
2. Snapshot version validation was overly strict and only permitted versions that were exactly SHA1. We now require that a snapshot artifact version _ends_ in SHA1.