### PR TITLE
Add version to uploaded apt package filename

### DIFF
--- a/apt/rules.bzl
+++ b/apt/rules.bzl
@@ -196,6 +196,7 @@ def _deploy_apt_impl(ctx):
             '{snapshot}' : ctx.attr.snapshot,
             '{release}' : ctx.attr.release,
             '{package_path}' : package_path,
+            '{version}' : ctx.var.get('version', '0.0.0')
         },
         is_executable = True
     )

--- a/apt/templates/deploy.py
+++ b/apt/templates/deploy.py
@@ -70,7 +70,7 @@ if not apt_password:
 
 package_path = "{package_path}"
 # Cloudsmith has a bug where packages with the same filename can break downloads
-uploaded_filename = package_path.rstrip(".deb") + "{version}.deb"
+uploaded_filename = package_path.rstrip(".deb") + "_{version}.deb"
 
 uploader = Uploader.create(apt_username, apt_password, repo_url)
 uploader.apt(package_path, uploaded_filename=uploaded_filename)

--- a/apt/templates/deploy.py
+++ b/apt/templates/deploy.py
@@ -69,8 +69,10 @@ if not apt_password:
     )
 
 package_path = "{package_path}"
+# Cloudsmith has a bug where packages with the same filename can break downloads
+uploaded_filename = package_path.rstrip(".deb") + "{version}.deb"
 
 uploader = Uploader.create(apt_username, apt_password, repo_url)
-uploader.apt(package_path)
+uploader.apt(package_path, uploaded_filename=uploaded_filename)
 
 print('Deployment completed.')

--- a/common/uploader/cloudsmith.py
+++ b/common/uploader/cloudsmith.py
@@ -88,11 +88,12 @@ class CloudsmithUploader(Uploader):
         return preferred_filename if preferred_filename else os.path.basename(path)
 
     # Specific
-    def apt(self, deb_file, distro="any-distro/any-version", opts={}):
+    def apt(self, deb_file, distro="any-distro/any-version", uploaded_filename = None, opts={}):
         accepted_opts = set()
         self._validate_opts(opts, accepted_opts)
         # The uploaded filename is irrelevant. Cloudsmith sync will take care of it.
-        uploaded_id = self._upload_file(deb_file, os.path.basename(deb_file))
+        uploaded_filename = os.path.basename(deb_file) if uploaded_filename is None else uploaded_filename
+        uploaded_id = self._upload_file(deb_file, uploaded_filename)
         data = {
             "package_file": uploaded_id,
             "distribution": distro,


### PR DESCRIPTION
## What is the goal of this PR?
The version is added to the uploaded filename of apt packages when being deployed. Without this, Cloudsmith's APT fetch ends up corrupted and downloads the wrong package, when multiple packages share the same file name across different versions.

## What are the changes implemented in this PR?
* Adds a line in the deployment script to upload `package.deb` as `package_version.deb` on cloudsmith
