### PR TITLE
Fix docs target build

### DIFF
--- a/doc_hub.bzl
+++ b/doc_hub.bzl
@@ -47,7 +47,7 @@ load("//common/tgz2zip:rules.bzl", _tgz2zip = "tgz2zip")
 
 load("//crates:rules.bzl", _assemble_crate = "assemble_crate", _deploy_crate = "deploy_crate")
 
-load("//docs/cpp:rules.bzl", _doxygen_docs = "doxygen_docs")
+load("//docs/doxygen:rules.bzl", _doxygen_docs = "doxygen_docs")
 load("//docs/python:rules.bzl", _sphinx_docs = "sphinx_docs")
 
 load("//gcp:rules.bzl", _assemble_gcp = "assemble_gcp")

--- a/nuget/rules.bzl
+++ b/nuget/rules.bzl
@@ -17,7 +17,6 @@
 
 # This file is based on the original implementation of https://github.com/SeleniumHQ/selenium/.
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_dotnet//dotnet/private:common.bzl", "is_debug")
 load("@rules_dotnet//dotnet/private:providers.bzl", "DotnetAssemblyRuntimeInfo")
 
@@ -29,7 +28,7 @@ load("@rules_dotnet//dotnet/private:providers.bzl", "DotnetAssemblyRuntimeInfo")
 # The `MSBuildEnableWorkloadResolver` is disabled to prevent warnings
 # about a missing Microsoft.NET.SDK.WorkloadAutoImportPropsLocator
 
-def dotnet_preamble(toolchain):
+def _dotnet_preamble(toolchain):
     return """
 export DOTNET="$(pwd)/{dotnet}"
 export DOTNET_CLI_HOME="$(dirname $DOTNET)"
@@ -177,7 +176,7 @@ def _nuget_pack_impl(ctx):
         mnemonic = "LayoutNugetPackages",
     )
 
-    cmd = dotnet_preamble(toolchain) + \
+    cmd = _dotnet_preamble(toolchain) + \
           "mkdir {}-working-dir && ".format(ctx.label.name) + \
           "echo $(pwd) && " + \
           "$(location @bazel_tools//tools/zip:zipper) x {} -d {}-working-dir && ".format(zip_file.path, ctx.label.name) + \
@@ -334,7 +333,6 @@ _nuget_push = rule(
         "@rules_dotnet//dotnet:toolchain_type",
     ],
 )
-
 
 def nuget_push(name, src, snapshot_url, release_url, **kwargs):
     push_script_name = "{}_script".format(name)


### PR DESCRIPTION
We fixed the build issues with the doc target, that appeared because of the `cpp` dir renaming in[ the previous PR](https://github.com/vaticle/bazel-distribution/pull/406), and some code style in the meantime.