### PR TITLE
Upgrade Packer and increase GCP packer image disk size

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,6 +101,3 @@ load("//common/uploader:deps.bzl", uploader_deps = "deps")
 uploader_deps()
 load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
 install_uploader_deps()
-
-load("//packer:deps.bzl", packer_deps = "deps")
-packer_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,3 +101,6 @@ load("//common/uploader:deps.bzl", uploader_deps = "deps")
 uploader_deps()
 load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
 install_uploader_deps()
+
+load("//packer:deps.bzl", packer_deps = "deps")
+packer_deps()

--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -14,7 +14,7 @@
       "image_name": "{image_name}",
       "image_family": "{image_family}",
       "image_licenses": {image_licenses},
-      "disk_size": 20,
+      "disk_size": 50,
       "disable_default_service_account": {disable_default_service_account}
     }
   ],

--- a/packer/deps.bzl
+++ b/packer/deps.bzl
@@ -22,14 +22,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def deps():
     http_archive(
         name = "packer_osx",
-        url = "https://releases.hashicorp.com/packer/1.7.4/packer_1.7.4_darwin_amd64.zip",
-        sha256 = "f3faf9dce0cebdfc7abfcf70511c6230e0c0a5c499ca3478def81549ded91b20",
-        build_file_content = 'exports_files(["packer"])'
+        build_file_content = 'exports_files(["packer"])',
+        url = "https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_darwin_amd64.zip",
     )
 
     http_archive(
         name = "packer_linux",
-        url = "https://releases.hashicorp.com/packer/1.7.4/packer_1.7.4_linux_amd64.zip",
-        sha256 = "3660064a56a174a6da5c37ee6b36107098c6b37e35cc84feb2f7f7519081b1b0",
-        build_file_content = 'exports_files(["packer"])'
+        build_file_content = 'exports_files(["packer"])',
+        url = "https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_linux_amd64.zip",
     )

--- a/packer/deps.bzl
+++ b/packer/deps.bzl
@@ -24,10 +24,12 @@ def deps():
         name = "packer_osx",
         build_file_content = 'exports_files(["packer"])',
         url = "https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_darwin_amd64.zip",
+        sha256 = "ef1ceaaafcdada65bdbb45793ad6eedbc7c368d415864776b9d3fa26fb30b896"
     )
 
     http_archive(
         name = "packer_linux",
         build_file_content = 'exports_files(["packer"])',
         url = "https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_linux_amd64.zip",
+        sha256 = "0587f7815ed79589cd9c2b754c82115731c8d0b8fd3b746fe40055d969facba5"
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've upgraded Packer to 1.8.3 and increased the GCP packer image disk size to 50GB.

## What are the changes implemented in this PR?

As above.