### PR TITLE
pass twine publish args in deploy_pip

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -184,7 +184,8 @@ def _deploy_pip_impl(ctx):
             "{snapshot}": ctx.attr.snapshot,
             "{release}": ctx.attr.release,
             "{distribution_tag}": ctx.attr.distribution_tag,
-            "{suffix}": ctx.attr.suffix,
+            "{suffix}": ctx.attr.suffix,         
+            "{publish_args}": str(ctx.attr.publish_args),
         }
     )
 
@@ -327,6 +328,10 @@ _deploy_pip = rule(
             default = "",
             doc = "Repository name in the .pypirc profile to deploy to"
         ),
+        "publish_args": attr.string_list(
+            default = [],
+            doc = """Arguments passed to twine, e.g. ["--non-interactive", "--skip-existing"]"""
+        ),
         "distribution_tag": attr.string(
             mandatory = True,
             doc = "Specify tag for the package name. Format: {python tag}-{abi tag}-{platform tag} (PEP 425)",
@@ -380,7 +385,8 @@ _deploy_pip = rule(
         """
 )
 
-def deploy_pip(name, target, snapshot, release, suffix = "", distribution_tag = "py3-none-any"):
+def deploy_pip(name, target, snapshot, release, suffix = "", distribution_tag = "py3-none-any",  publish_args = []):
+
     deploy_script_target_name = name + "__deploy"
     deploy_script_name = deploy_script_target_name + "-deploy.py"
     _deploy_pip(
@@ -391,6 +397,7 @@ def deploy_pip(name, target, snapshot, release, suffix = "", distribution_tag = 
         release = release,
         suffix = suffix,
         distribution_tag = distribution_tag,
+        publish_args = publish_args
     )
 
     native.py_binary(

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -42,6 +42,8 @@ repositories = {
     SNAPSHOT_KEY: "{snapshot}",
     RELEASE_KEY: "{release}"
 }
+publish_args = {publish_args}
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('repo_type')
@@ -52,14 +54,14 @@ def upload_command(repo_type_key, packages):
         raise Exception(f"Selected repository must be one of: {list(repositories.keys())}")
 
     if repo_type_key == PYPIRC_KEY:
-        return packages + ['--repository', repositories[repo_type_key]]
+        return packages + ['--repository', repositories[repo_type_key]] + publish_args
     elif repo_type_key == SNAPSHOT_KEY or repo_type_key == RELEASE_KEY:
         pip_username, pip_password = (os.getenv(ENV_DEPLOY_PIP_USERNAME), os.getenv(ENV_DEPLOY_PIP_PASSWORD))
         if not pip_username:
             raise Exception(f"username should be passed via the {ENV_DEPLOY_PIP_USERNAME} environment variable")
         if not pip_password:
             raise Exception(f"password should be passed via the {ENV_DEPLOY_PIP_PASSWORD} environment variable")
-        return packages + ['-u', pip_username, '-p', pip_password, '--repository-url', repositories[repo_type_key]]
+        return packages + ['-u', pip_username, '-p', pip_password, '--repository-url', repositories[repo_type_key]] + publish_args
     else:
         raise Exception(f"Unrecognised repository selector: {repo_type_key}")
 


### PR DESCRIPTION
## What is the goal of this PR?

Be able to pass twine args eg `--skip-existing` , "--non-interactive"

## What are the changes implemented in this PR?

Pass twine publish args in `deploy_pip` function


Live tested on private repository together with other waiting PRs https://github.com/mgosk/bazel-distribution/tree/bzlmod-with-pypi