### PR TITLE
Remove leading and trailing whitespaces from VERSION files for crate and maven assembly rules

### DIFF
--- a/crates/CrateAssembler.kt
+++ b/crates/CrateAssembler.kt
@@ -180,7 +180,7 @@ class CrateAssembler : Callable<Unit> {
     }
 
     private fun writeCrateArchive(config: UnmodifiableConfig) {
-        val prefix = "$name-${versionFile.readText()}"
+        val prefix = "$name-${versionFile.readText().trim()}"
         outputCrateFile.outputStream().use { fos ->
             BufferedOutputStream(fos).use { bos ->
                 GZIPOutputStream(bos).use { gzos ->
@@ -235,7 +235,7 @@ class CrateAssembler : Callable<Unit> {
             cargoToml.set<Config>("package", this)
             set<String>("name", name)
             set<String>("edition", edition)
-            set<String>("version", tagToVersion(versionFile.readText()))
+            set<String>("version", tagToVersion(versionFile.readText().trim()))
             set<Array<String>>("authors", authors.filter { it != "" })
             set<String>("homepage", homepage)
             set<String>("repository", repository)

--- a/maven/PomGenerator.kt
+++ b/maven/PomGenerator.kt
@@ -191,7 +191,7 @@ class PomGenerator : Callable<Unit> {
     }
 
     override fun call() {
-        val version = tagToVersion(versionFile.readText())
+        val version = tagToVersion(versionFile.readText().trim())
         val workspaceRefs = Json.parse(workspaceRefsFile.readText()).asObject()
 
         // Create an XML document for constructing the POM

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -68,7 +68,6 @@ def _generate_pom_file(ctx, version_file):
         pom_dependency_coordinates = _parse_maven_coordinates(pom_dependency, False)
         pom_dependency_artifact = pom_dependency_coordinates.group_id + ":" + pom_dependency_coordinates.artifact_id
         pom_dependency_version = pom_dependency_coordinates.version
-
         version = ctx.attr.version_overrides.get(pom_dependency_artifact, pom_dependency_version)
         pom_deps.append(pom_dependency_artifact + ":" + version)
 

--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -68,6 +68,7 @@ def _generate_pom_file(ctx, version_file):
         pom_dependency_coordinates = _parse_maven_coordinates(pom_dependency, False)
         pom_dependency_artifact = pom_dependency_coordinates.group_id + ":" + pom_dependency_coordinates.artifact_id
         pom_dependency_version = pom_dependency_coordinates.version
+
         version = ctx.attr.version_overrides.get(pom_dependency_artifact, pom_dependency_version)
         pom_deps.append(pom_dependency_artifact + ":" + version)
 

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -82,7 +82,7 @@ if version is None or len(version.text) == 0:
 version = version.text
 
 if version != version.strip():
-    raise Exception('Version "{}" has leading or trailing spaces or special characters'.format(version))
+    raise Exception('Version "{}" has leading or trailing whitespaces'.format(version))
 
 snapshot = 'snapshot'
 version_snapshot_regex = '^[0-9]+.[0-9]+.[0-9]+-[0-9|a-f|A-F]{40}$|.*-SNAPSHOT$'

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -81,6 +81,9 @@ if version is None or len(version.text) == 0:
 
 version = version.text
 
+if version != version.strip():
+    raise Exception('Version "{}" has leading or trailing spaces or special characters'.format(version))
+
 snapshot = 'snapshot'
 version_snapshot_regex = '^[0-9]+.[0-9]+.[0-9]+-[0-9|a-f|A-F]{40}$|.*-SNAPSHOT$'
 release = 'release'


### PR DESCRIPTION
## What is the goal of this PR?

We resolve issue #380 by trimming input `version` values from `VERSION` files for `maven` and `crate` artifacts assembly rules. It solves the problem of `VERSION` files being passed as `version_file` to the respective rules after being formatted to have an additional empty line in the end, which is a standard convention for files and a common IDE setting, or just being formatted incorrectly while containing a valid value.

From now on, `VERSION` files passed into `assemble_maven` and `assemble_crate` can have any leading and trailing whitespaces.

## What are the changes implemented in this PR?

We add `trim()` calls for all the `.kt` scripts reading `version` files. This behavior used to exist for many `.py` scripts (with `strip()` for `Python` `string`), but these places were left forgotten (and not noticed by us as we use `--define version=$(cat VERSION)` in most of our assembly pipelines).
We also add a respective check for trimmed `version` values into the `maven` deployment script to prevent users from forgetting to format their input `version`s while using any `pom` file as it can lead to corrupted snapshots, snapshot repositories `URL`s, and other automation failures.
