### PR TITLE
In `assemble_apt`, make dependency declarations optional

### DIFF
--- a/apt/generate_depends_file.py
+++ b/apt/generate_depends_file.py
@@ -28,8 +28,8 @@ WORKSPACE_REF_PATTERN = re.compile(r'.*%{@(?P<workspace_ref>.*)}.*')
 parser = argparse.ArgumentParser()
 parser.add_argument('--output', required=True, help='Output file')
 parser.add_argument('--version_file', required=True, help='File containing version of package being built')
-parser.add_argument('--workspace_refs', help='Optional file with workspace references')
-parser.add_argument('--deps', nargs='+', required=True, help='Dependency declarations')
+parser.add_argument('--workspace_refs', help='File with workspace references (optional)')
+parser.add_argument('--deps', nargs='+', help='Dependency declarations (optional)')
 args = parser.parse_args()
 
 workspace_refs = {
@@ -60,7 +60,7 @@ for ws, tag in workspace_refs['tags'].items():
 
 deps = []
 
-for dep in args.deps:
+for dep in (args.deps or []):
     match = WORKSPACE_REF_PATTERN.match(dep)
     if match:
         workspace_ref = match.group('workspace_ref')

--- a/apt/rules.bzl
+++ b/apt/rules.bzl
@@ -152,10 +152,12 @@ def assemble_apt(name,
         "$(location @vaticle_bazel_distribution//apt:generate_depends_file)",
         "--output", "$@",
         "--version_file", "$(location {})".format(version_file),
-        "--deps"
     ]
-    for dep in depends:
-        args.append('"{}"'.format(dep))
+    if len(depends):
+        args.append("--deps")
+        for dep in depends:
+            args.append('"{}"'.format(dep))
+
     srcs = [version_file]
 
     if workspace_refs:


### PR DESCRIPTION
## What is the goal of this PR?

Dependency declarations in `assemble_apt` (`depends`) are now optional. This allows for the publishing of APT packages that have no dependencies.

## What are the changes implemented in this PR?

- Make `--deps` optional in the Python script that powers `assemble_apt`
- Make the `assemble_apt` rule not crash with `depends` unspecified