### PR TITLE
Handle output directory differently in python sphinx_docs rule (#424)

### DIFF
--- a/docs/python/rules.bzl
+++ b/docs/python/rules.bzl
@@ -19,7 +19,7 @@
 
 def _sphinx_docs_impl(ctx):
     package = ctx.actions.declare_directory("package")
-
+    out_dir = ctx.actions.declare_directory(ctx.attr.out)
     ctx.actions.run_shell(
         inputs = ctx.files.target,
         outputs = [package],
@@ -28,19 +28,19 @@ def _sphinx_docs_impl(ctx):
     )
 
     args = ctx.actions.args()
-    args.add('--output', ctx.outputs.out.path)
+    args.add('--output', out_dir.path)
     args.add('--package', package.path)
     args.add('--source_dir', ctx.files.sphinx_conf[0].dirname)
 
     ctx.actions.run(
         inputs = [ctx.executable._script, package] + ctx.files.sphinx_conf + ctx.files.sphinx_rst,
-        outputs = [ctx.outputs.out],
+        outputs = [out_dir],
         arguments = [args],
         executable = ctx.executable._script,
         env = {"PYTHONPATH": package.path},
     )
 
-    return DefaultInfo(files = depset([ctx.outputs.out]))
+    return DefaultInfo(files = depset([out_dir]))
 
 
 sphinx_docs = rule(
@@ -66,7 +66,7 @@ sphinx_docs = rule(
             allow_files = True,
             doc = "Sphinx documentation master file for the package",
         ),
-        "out": attr.output(
+        "out": attr.string(
             mandatory = True,
             doc = "Output directory",
         ),


### PR DESCRIPTION
## Usage and product changes
explicitly `declare_directory` for output directories in bazel, rather than relying on `attr.output`

## Motivation
bazel would complain that the output directory is not created.

## Implementation
The sphinx_docs rule now accepts output directory path as `attr.string` instead of `attr.output` and the rule_impl converts this to a directory using `ctx.actions.declare_directory`

## Usage and product changes


## Motivation


## Implementation
