### PR TITLE
Fix Bzlmod compatibility for deploy scripts 

### DIFF
--- a/apt/templates/deploy.py
+++ b/apt/templates/deploy.py
@@ -31,12 +31,7 @@ import tarfile
 import tempfile
 from runpy import run_path
 
-import sys, glob
-# Prefer using the runfile dependency than system dependency
-runfile_deps = [path for path in map(os.path.abspath, glob.glob('external/*/*'))]
-sys.path = runfile_deps + sys.path
-
-from common.uploader.uploader import Uploader
+from uploader import Uploader
 
 parser = argparse.ArgumentParser()
 parser.add_argument('repo_type')

--- a/artifact/templates/deploy.py
+++ b/artifact/templates/deploy.py
@@ -27,12 +27,7 @@ import subprocess as sp
 import sys
 from posixpath import join as urljoin
 
-import glob
-# Prefer using the runfile dependency than system dependency
-runfile_deps = [path for path in map(os.path.abspath, glob.glob('external/*/*'))]
-sys.path = runfile_deps + sys.path
-
-from common.uploader.uploader import Uploader
+from uploader import Uploader
 
 if len(sys.argv) != 2:
     raise ValueError('Should pass only <snapshot|release> as arguments')

--- a/common/uploader/BUILD
+++ b/common/uploader/BUILD
@@ -21,6 +21,7 @@ load("@typedb_bazel_distribution_uploader//:requirements.bzl", cloudsmith_requir
 py_library(
     name = "uploader",
     srcs = glob(["*.py"]),
+    imports = ["."],
     deps = [cloudsmith_requirement("requests")],
     visibility = ["//visibility:public"],
 )

--- a/common/uploader/cloudsmith.py
+++ b/common/uploader/cloudsmith.py
@@ -2,7 +2,7 @@ import os
 import re
 import requests
 import time
-from .uploader import Uploader, DeploymentException
+from uploader import Uploader, DeploymentException
 
 class CloudsmithUploader(Uploader):
     COMMON_OPTS = {"tags"}

--- a/common/uploader/nexus.py
+++ b/common/uploader/nexus.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 import requests
 
-from .uploader import Uploader, DeploymentException
+from uploader import Uploader, DeploymentException
 
 class NexusUploader(Uploader):
     COMMON_OPTS = set()
@@ -55,7 +55,7 @@ class NexusUploader(Uploader):
             success = (response.status_code // 100)== 2
 
         if not success:
-            from .cloudsmith import  DeploymentException
+            from cloudsmith import DeploymentException
             raise DeploymentException("HTTP request for %s failed" % stage, response)
         else:
             return True

--- a/common/uploader/uploader.py
+++ b/common/uploader/uploader.py
@@ -16,10 +16,10 @@ class Uploader(ABC):
     @staticmethod
     def create(username, password, repo_url):
         if repo_url.startswith("cloudsmith"):
-            from .cloudsmith import CloudsmithUploader
+            from cloudsmith import CloudsmithUploader
             return CloudsmithUploader(username, password, repo_url)
         elif repo_url.startswith("http"):
-            from .nexus import NexusUploader
+            from nexus import NexusUploader
             return NexusUploader(username, password, repo_url)
         else:
             raise ValueError("Unrecognised url: ", repo_url)

--- a/helm/templates/deploy.py
+++ b/helm/templates/deploy.py
@@ -27,12 +27,7 @@ import subprocess as sp
 import sys
 from posixpath import join as urljoin
 
-import glob
-# Prefer using the runfile dependency than system dependency
-runfile_deps = [path for path in map(os.path.abspath, glob.glob('external/*/*'))]
-sys.path = runfile_deps + sys.path
-
-from common.uploader.uploader import Uploader
+from uploader import Uploader
 
 if len(sys.argv) != 2:
     raise ValueError('Should pass only <snapshot|release> as arguments')

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -30,13 +30,7 @@ import sys
 import tempfile
 from posixpath import join as urljoin
 
-import sys, glob
-
-# Prefer using the runfile dependency than system dependency
-runfile_deps = [path for path in map(os.path.abspath, glob.glob('external/*/*'))]
-sys.path = runfile_deps + sys.path
-
-from common.uploader.uploader import Uploader
+from uploader import Uploader
 
 
 def unpack_args(_, a, b=False):

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -19,14 +19,10 @@
 # under the License.
 #
 import argparse
-import glob
 import os
 import shutil
 import sys
 
-# Prefer using the runfile dependency than system dependency
-runfile_deps = [path for path in map(os.path.abspath, glob.glob('external/*/*'))]
-sys.path = runfile_deps + sys.path
 # noinspection PyUnresolvedReferences
 import twine.commands.upload
 


### PR DESCRIPTION
## Usage and product changes

Fix Bzlmod compatibility for deploy scripts 

## Motivation

The deploy-maven jobs were observed to be broken in some repos.

## Implementation

Under Bzlmod, the `common/uploader` package from `bazel-distribution` conflicts with the consuming repo's own `common/` package in the Python runfiles tree. Both repos place a `common/` directory on `sys.path`, and Python finds the consuming repo's `common/` first, never discovering the `uploader` subpackage.

Additionally, the old `sys.path` hack (`glob('external/*/*')`) no longer works because Bzlmod places external repos at the runfiles root level, not under `external/`.

The fix adds `imports = ["."]` to the uploader `py_library`, which puts `common/uploader/` directly on the Python path. All deploy templates and uploader modules are updated to use flat imports (`from uploader import Uploader`) instead of package-relative imports (`from common.uploader.uploader import Uploader`, `from .cloudsmith import ...`). The obsolete `sys.path` hack is removed from all 5 deploy templates (maven, artifact, apt, helm, pip).