### PR TITLE
Fix deploy_pip's py_binary build

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -407,5 +407,10 @@ def deploy_pip(name, target, snapshot, release, suffix = "", distribution_tag = 
         name = name,
         srcs = [deploy_script_target_name],
         main = deploy_script_name,
-        deps = [Label("//common/uploader:uploader")],
+        deps = [
+            Label("//common/uploader:uploader"),
+            typedb_bazel_distribution_requirement("twine"),
+            typedb_bazel_distribution_requirement("setuptools"),
+            typedb_bazel_distribution_requirement("wheel"),
+        ],
     )


### PR DESCRIPTION
## Usage and product changes

Resolve `py_binary`'s dependencies issues found in CI.

## Motivation

The `deploy_pip` macro's `py_binary` fails at runtime with `ModuleNotFoundError: No module named 'twine' under Bzlmod`. The generated deploy script imports `twine.commands.upload`, but the `py_binary` wrapping it only depends on `//common/uploader:uploader` — it never receives the pip dependencies (`twine`, `setuptools`, `wheel`) that the `_deploy_pip` rule collects via its _deps attribute.                                                                                        

The `_deploy_pip` rule correctly declares these dependencies and includes them in its runfiles, but the `deploy_pip` macro creates a separate py_binary that doesn't propagate them. Under Bzlmod, the system Python packages aren't visible to sandboxed actions, so the missing deps cause a runtime import failure.
                                                                                                                           
## Implementation
                                                                                                                      
Add `twine`, `setuptools`, and `wheel` from `@typedb_bazel_distribution_pip` to the `py_binary`'s deps in the `deploy_pip` macro, matching the `_deps` already declared on the `_deploy_pip` rule.
