### PR TITLE
Speed up CI with various fixes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -109,6 +109,7 @@ use_repo(
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
+    name = "bazel_distribution_maven",
     artifacts = [
         "com.eclipsesource.minimal-json:minimal-json:0.9.5",
         "com.electronwill.night-config:core:3.6.5",
@@ -124,7 +125,7 @@ maven.install(
     ],
     strict_visibility = True,
 )
-use_repo(maven, "maven")
+use_repo(maven, "bazel_distribution_maven")
 
 # ===========================================================
 # Assembly & deployments

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -84,6 +84,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/MODULE.bazel": "f006f845f5e75c5a3e691947062bf33cfef66d2b66af9f1d5f6a35fc99d4ed78",
+    "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/source.json": "0fd3ac33da1afa98261a99251396e99eab82261739aa81beee6c814cc83b897e",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -158,6 +160,72 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@rules_dotnet+//dotnet:extensions.bzl%dotnet": {
+      "general": {
+        "bzlTransitiveDigest": "rjQ1lfCCmBPTcuoXxuj+2PRXph88EtNicFgnepUslJM=",
+        "usagesDigest": "y75g1jmYU1fblpSxK54Wn05KoJnAdHF2DKN2jEzjg8U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "dotnet_x86_64-apple-darwin": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "x86_64-apple-darwin",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_aarch64-apple-darwin": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "aarch64-apple-darwin",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_x86_64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "x86_64-unknown-linux-gnu",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_arm64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "arm64-unknown-linux-gnu",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_x86_64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "x86_64-pc-windows-msvc",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_arm64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "arm64-pc-windows-msvc",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_toolchains": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "user_repository_name": "dotnet"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "BPtcNR+6+tfwR+Tr7/VtqG+w2KpGo1RAIG3meFBwJWo=",

--- a/common/shell/BUILD
+++ b/common/shell/BUILD
@@ -25,7 +25,7 @@ kt_jvm_library(
     deps = [
         "@typedb_bazel_distribution//common",
 
-        "@maven//:org_zeroturnaround_zt_exec",
+        "@bazel_distribution_maven//:org_zeroturnaround_zt_exec",
     ],
     visibility = ["//visibility:public"],
 )

--- a/crates/BUILD
+++ b/crates/BUILD
@@ -38,11 +38,11 @@ kt_jvm_library(
         "CrateAssembler.kt",
     ],
     deps = [
-        "@maven//:com_eclipsesource_minimal_json_minimal_json",
-        "@maven//:com_electronwill_night_config_core",
-        "@maven//:com_electronwill_night_config_toml",
-        "@maven//:info_picocli_picocli",
-        "@maven//:org_apache_commons_commons_compress",
+        "@bazel_distribution_maven//:com_eclipsesource_minimal_json_minimal_json",
+        "@bazel_distribution_maven//:com_electronwill_night_config_core",
+        "@bazel_distribution_maven//:com_electronwill_night_config_toml",
+        "@bazel_distribution_maven//:info_picocli_picocli",
+        "@bazel_distribution_maven//:org_apache_commons_commons_compress",
     ],
 )
 
@@ -61,9 +61,9 @@ kt_jvm_library(
         "CrateDeployer.kt",
     ],
     deps = [
-        "@maven//:com_eclipsesource_minimal_json_minimal_json",
-        "@maven//:com_google_http_client_google_http_client",
-        "@maven//:info_picocli_picocli",
+        "@bazel_distribution_maven//:com_eclipsesource_minimal_json_minimal_json",
+        "@bazel_distribution_maven//:com_google_http_client_google_http_client",
+        "@bazel_distribution_maven//:info_picocli_picocli",
     ],
 )
 

--- a/maven/BUILD
+++ b/maven/BUILD
@@ -35,8 +35,8 @@ bzl_library(
 kt_jvm_library(
     name = "pom-generator-lib",
     deps = [
-      "@maven//:com_eclipsesource_minimal_json_minimal_json",
-      "@maven//:info_picocli_picocli",
+      "@bazel_distribution_maven//:com_eclipsesource_minimal_json_minimal_json",
+      "@bazel_distribution_maven//:info_picocli_picocli",
     ],
     srcs = [
         "PomGenerator.kt",
@@ -56,7 +56,7 @@ java_binary(
 kt_jvm_library(
     name = "jar-assembler-lib",
     deps = [
-      "@maven//:info_picocli_picocli",
+      "@bazel_distribution_maven//:info_picocli_picocli",
     ],
     srcs = [
         "JarAssembler.kt"

--- a/npm/deploy/BUILD
+++ b/npm/deploy/BUILD
@@ -38,8 +38,8 @@ kt_jvm_library(
         "@typedb_bazel_distribution//common/shell",
         "@typedb_bazel_distribution//common/util",
 
-        "@maven//:info_picocli_picocli",
-        "@maven//:org_zeroturnaround_zt_exec",
+        "@bazel_distribution_maven//:info_picocli_picocli",
+        "@bazel_distribution_maven//:org_zeroturnaround_zt_exec",
     ],
 )
 

--- a/nuget/rules.bzl
+++ b/nuget/rules.bzl
@@ -66,7 +66,9 @@ def _parse_version(ctx):
     version = ctx.attr.version
     if not version:
         version = ctx.var.get("version", "0.0.0")
-
+    if len(version) == 40:
+        # this is a commit SHA, most likely
+        version = "0.0.0-{}".format(version)
     return version
 
 

--- a/platform/jvm/BUILD
+++ b/platform/jvm/BUILD
@@ -36,8 +36,8 @@ kt_jvm_library(
         "@typedb_bazel_distribution//common/shell",
         "@typedb_bazel_distribution//common/util",
 
-        "@maven//:info_picocli_picocli",
-        "@maven//:org_zeroturnaround_zt_exec",
+        "@bazel_distribution_maven//:info_picocli_picocli",
+        "@bazel_distribution_maven//:org_zeroturnaround_zt_exec",
     ],
 )
 


### PR DESCRIPTION
## Usage and product changes
We use a custom namespace for the maven dependencies repo of the distribution tools, preventing clashes with a protobuf dependency update. We also update the nuget publishing job to append the `0.0.0-` to the commit-sha, so bazel doesn't discard the cache because the `--define version` changed.