### PR TITLE
Fix CI pipelines after rules_python upgrade

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,19 +90,19 @@ bazel_dep(name = "platforms", version = "0.0.10")
 # Pip
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
-    hub_name = "typedb_bazel_distribution_pip",
+    hub_name = "pip_tdb",
     python_version = "3.11",
     requirements_lock = "//:pip/requirements.txt",
 )
 pip.parse(
-    hub_name = "typedb_bazel_distribution_uploader",
+    hub_name = "pip_uploader",
     python_version = "3.11",
     requirements_lock = "//:common/uploader/requirements.txt",
 )
 use_repo(
     pip,
-    "typedb_bazel_distribution_pip",
-    "typedb_bazel_distribution_uploader",
+    "pip_tdb",
+    "pip_uploader",
 )
 
 # Maven

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -431,7 +431,7 @@
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
         "bzlTransitiveDigest": "Ow3uwXpFcSZvHlKK1YJSrPYu0HnV+9MA73NlTEA9YWQ=",
-        "usagesDigest": "BgWt+UrtFMud3oKLHYV0TeFzlS71G2S7lM+LFAb1Wt8=",
+        "usagesDigest": "AcmN7hVW7EzMAWFOBZtuddafjphR50Gb6IxjZ+6x4vU=",
         "recordedFileInputs": {
           "@@//common/uploader/requirements.txt": "e5c11781d710b5c4b6967500324eeaedae6d8750ef2b93c1588a86bcc53f419e",
           "@@//docs/python/requirements.txt": "d8876319767ca59cfc86525d7a9a6d9e6f9202565b1df1deadb7cbf9afabdd03",
@@ -539,6 +539,393 @@
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "pip_deps_39",
               "requirement": "setuptools<=70.3.0"
+            }
+          },
+          "pip_tdb_311_bleach": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "bleach==6.0.0"
+            }
+          },
+          "pip_tdb_311_certifi": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "certifi==2022.12.7"
+            }
+          },
+          "pip_tdb_311_cffi": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "cffi==1.15.1"
+            }
+          },
+          "pip_tdb_311_chardet": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "chardet==5.1.0"
+            }
+          },
+          "pip_tdb_311_charset_normalizer": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "charset-normalizer==3.0.1"
+            }
+          },
+          "pip_tdb_311_colorama": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "colorama==0.4.6"
+            }
+          },
+          "pip_tdb_311_cryptography": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "cryptography==39.0.0"
+            }
+          },
+          "pip_tdb_311_docutils": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "docutils==0.19"
+            }
+          },
+          "pip_tdb_311_idna": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "idna==3.4"
+            }
+          },
+          "pip_tdb_311_importlib_metadata": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "importlib-metadata==6.0.0"
+            }
+          },
+          "pip_tdb_311_importlib_resources": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "importlib-resources==5.10.2"
+            }
+          },
+          "pip_tdb_311_jaraco_classes": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "jaraco-classes==3.2.3"
+            }
+          },
+          "pip_tdb_311_jeepney": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "jeepney==0.8.0"
+            }
+          },
+          "pip_tdb_311_keyring": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "keyring==23.13.1"
+            }
+          },
+          "pip_tdb_311_markdown_it_py": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "markdown-it-py==2.1.0"
+            }
+          },
+          "pip_tdb_311_mdurl": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "mdurl==0.1.2"
+            }
+          },
+          "pip_tdb_311_more_itertools": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "more-itertools==9.0.0"
+            }
+          },
+          "pip_tdb_311_packaging": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "packaging==23.0"
+            }
+          },
+          "pip_tdb_311_pkginfo": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "pkginfo==1.9.6"
+            }
+          },
+          "pip_tdb_311_pycparser": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "pycparser==2.21"
+            }
+          },
+          "pip_tdb_311_pygments": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "pygments==2.14.0"
+            }
+          },
+          "pip_tdb_311_pyparsing": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "pyparsing==3.0.9"
+            }
+          },
+          "pip_tdb_311_pywin32_ctypes": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "pywin32-ctypes==0.2.2; sys_platform == 'win32'"
+            }
+          },
+          "pip_tdb_311_readme_renderer": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "readme-renderer==37.3"
+            }
+          },
+          "pip_tdb_311_requests": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "requests==2.28.2"
+            }
+          },
+          "pip_tdb_311_requests_toolbelt": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "requests-toolbelt==0.10.1"
+            }
+          },
+          "pip_tdb_311_rfc3986": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "rfc3986==2.0.0"
+            }
+          },
+          "pip_tdb_311_rich": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "rich==13.2.0"
+            }
+          },
+          "pip_tdb_311_secretstorage": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "secretstorage==3.3.3"
+            }
+          },
+          "pip_tdb_311_setuptools": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "setuptools==65.0.0"
+            }
+          },
+          "pip_tdb_311_six": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "pip_tdb_311_tqdm": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "tqdm==4.64.1"
+            }
+          },
+          "pip_tdb_311_twine": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "twine==4.0.2"
+            }
+          },
+          "pip_tdb_311_typing_extensions": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "typing-extensions==4.4.0"
+            }
+          },
+          "pip_tdb_311_urllib3": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "urllib3==1.26.14"
+            }
+          },
+          "pip_tdb_311_webencodings": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "webencodings==0.5.1"
+            }
+          },
+          "pip_tdb_311_wheel": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "wheel==0.38.4"
+            }
+          },
+          "pip_tdb_311_zipp": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_tdb//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_tdb_311",
+              "requirement": "zipp==3.11.0"
+            }
+          },
+          "pip_uploader_311_certifi": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_uploader//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_uploader_311",
+              "requirement": "certifi==2022.12.7"
+            }
+          },
+          "pip_uploader_311_charset_normalizer": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_uploader//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_uploader_311",
+              "requirement": "charset-normalizer==3.0.1"
+            }
+          },
+          "pip_uploader_311_idna": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_uploader//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_uploader_311",
+              "requirement": "idna==3.4"
+            }
+          },
+          "pip_uploader_311_requests": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_uploader//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_uploader_311",
+              "requirement": "requests==2.28.2"
+            }
+          },
+          "pip_uploader_311_urllib3": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@pip_uploader//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
+              "repo": "pip_uploader_311",
+              "requirement": "urllib3==1.26.14"
             }
           },
           "rules_fuzzing_py_deps_310_absl_py": {
@@ -3182,393 +3569,6 @@
               "requirement": "zipp==3.15.0"
             }
           },
-          "pip_tdb_311_bleach": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "bleach==6.0.0"
-            }
-          },
-          "pip_tdb_311_certifi": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "certifi==2022.12.7"
-            }
-          },
-          "pip_tdb_311_cffi": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "cffi==1.15.1"
-            }
-          },
-          "pip_tdb_311_chardet": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "chardet==5.1.0"
-            }
-          },
-          "pip_tdb_311_charset_normalizer": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "charset-normalizer==3.0.1"
-            }
-          },
-          "pip_tdb_311_colorama": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "colorama==0.4.6"
-            }
-          },
-          "pip_tdb_311_cryptography": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "cryptography==39.0.0"
-            }
-          },
-          "pip_tdb_311_docutils": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "docutils==0.19"
-            }
-          },
-          "pip_tdb_311_idna": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "idna==3.4"
-            }
-          },
-          "pip_tdb_311_importlib_metadata": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "importlib-metadata==6.0.0"
-            }
-          },
-          "pip_tdb_311_importlib_resources": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "importlib-resources==5.10.2"
-            }
-          },
-          "pip_tdb_311_jaraco_classes": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "jaraco-classes==3.2.3"
-            }
-          },
-          "pip_tdb_311_jeepney": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "jeepney==0.8.0"
-            }
-          },
-          "pip_tdb_311_keyring": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "keyring==23.13.1"
-            }
-          },
-          "pip_tdb_311_markdown_it_py": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "markdown-it-py==2.1.0"
-            }
-          },
-          "pip_tdb_311_mdurl": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "mdurl==0.1.2"
-            }
-          },
-          "pip_tdb_311_more_itertools": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "more-itertools==9.0.0"
-            }
-          },
-          "pip_tdb_311_packaging": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "packaging==23.0"
-            }
-          },
-          "pip_tdb_311_pkginfo": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "pkginfo==1.9.6"
-            }
-          },
-          "pip_tdb_311_pycparser": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "pycparser==2.21"
-            }
-          },
-          "pip_tdb_311_pygments": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "pygments==2.14.0"
-            }
-          },
-          "pip_tdb_311_pyparsing": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "pyparsing==3.0.9"
-            }
-          },
-          "pip_tdb_311_pywin32_ctypes": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "pywin32-ctypes==0.2.2; sys_platform == 'win32'"
-            }
-          },
-          "pip_tdb_311_readme_renderer": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "readme-renderer==37.3"
-            }
-          },
-          "pip_tdb_311_requests": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "requests==2.28.2"
-            }
-          },
-          "pip_tdb_311_requests_toolbelt": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "requests-toolbelt==0.10.1"
-            }
-          },
-          "pip_tdb_311_rfc3986": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "rfc3986==2.0.0"
-            }
-          },
-          "pip_tdb_311_rich": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "rich==13.2.0"
-            }
-          },
-          "pip_tdb_311_secretstorage": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "secretstorage==3.3.3"
-            }
-          },
-          "pip_tdb_311_setuptools": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "setuptools==65.0.0"
-            }
-          },
-          "pip_tdb_311_six": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "six==1.16.0"
-            }
-          },
-          "pip_tdb_311_tqdm": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "tqdm==4.64.1"
-            }
-          },
-          "pip_tdb_311_twine": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "twine==4.0.2"
-            }
-          },
-          "pip_tdb_311_typing_extensions": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "typing-extensions==4.4.0"
-            }
-          },
-          "pip_tdb_311_urllib3": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "urllib3==1.26.14"
-            }
-          },
-          "pip_tdb_311_webencodings": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "webencodings==0.5.1"
-            }
-          },
-          "pip_tdb_311_wheel": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "wheel==0.38.4"
-            }
-          },
-          "pip_tdb_311_zipp": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_tdb//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_tdb_311",
-              "requirement": "zipp==3.11.0"
-            }
-          },
-          "pip_uploader_311_certifi": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_uploader//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_uploader_311",
-              "requirement": "certifi==2022.12.7"
-            }
-          },
-          "pip_uploader_311_charset_normalizer": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_uploader//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_uploader_311",
-              "requirement": "charset-normalizer==3.0.1"
-            }
-          },
-          "pip_uploader_311_idna": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_uploader//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_uploader_311",
-              "requirement": "idna==3.4"
-            }
-          },
-          "pip_uploader_311_requests": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_uploader//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_uploader_311",
-              "requirement": "requests==2.28.2"
-            }
-          },
-          "pip_uploader_311_urllib3": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@pip_uploader//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "pip_uploader_311",
-              "requirement": "urllib3==1.26.14"
-            }
-          },
           "pip_deps": {
             "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
             "attributes": {
@@ -3581,6 +3581,115 @@
               "packages": [
                 "numpy",
                 "setuptools"
+              ],
+              "groups": {}
+            }
+          },
+          "pip_tdb": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
+            "attributes": {
+              "repo_name": "pip_tdb",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "bleach": "{\"pip_tdb_311_bleach\":[{\"version\":\"3.11\"}]}",
+                "certifi": "{\"pip_tdb_311_certifi\":[{\"version\":\"3.11\"}]}",
+                "cffi": "{\"pip_tdb_311_cffi\":[{\"version\":\"3.11\"}]}",
+                "chardet": "{\"pip_tdb_311_chardet\":[{\"version\":\"3.11\"}]}",
+                "charset_normalizer": "{\"pip_tdb_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
+                "colorama": "{\"pip_tdb_311_colorama\":[{\"version\":\"3.11\"}]}",
+                "cryptography": "{\"pip_tdb_311_cryptography\":[{\"version\":\"3.11\"}]}",
+                "docutils": "{\"pip_tdb_311_docutils\":[{\"version\":\"3.11\"}]}",
+                "idna": "{\"pip_tdb_311_idna\":[{\"version\":\"3.11\"}]}",
+                "importlib_metadata": "{\"pip_tdb_311_importlib_metadata\":[{\"version\":\"3.11\"}]}",
+                "importlib_resources": "{\"pip_tdb_311_importlib_resources\":[{\"version\":\"3.11\"}]}",
+                "jaraco_classes": "{\"pip_tdb_311_jaraco_classes\":[{\"version\":\"3.11\"}]}",
+                "jeepney": "{\"pip_tdb_311_jeepney\":[{\"version\":\"3.11\"}]}",
+                "keyring": "{\"pip_tdb_311_keyring\":[{\"version\":\"3.11\"}]}",
+                "markdown_it_py": "{\"pip_tdb_311_markdown_it_py\":[{\"version\":\"3.11\"}]}",
+                "mdurl": "{\"pip_tdb_311_mdurl\":[{\"version\":\"3.11\"}]}",
+                "more_itertools": "{\"pip_tdb_311_more_itertools\":[{\"version\":\"3.11\"}]}",
+                "packaging": "{\"pip_tdb_311_packaging\":[{\"version\":\"3.11\"}]}",
+                "pkginfo": "{\"pip_tdb_311_pkginfo\":[{\"version\":\"3.11\"}]}",
+                "pycparser": "{\"pip_tdb_311_pycparser\":[{\"version\":\"3.11\"}]}",
+                "pygments": "{\"pip_tdb_311_pygments\":[{\"version\":\"3.11\"}]}",
+                "pyparsing": "{\"pip_tdb_311_pyparsing\":[{\"version\":\"3.11\"}]}",
+                "pywin32_ctypes": "{\"pip_tdb_311_pywin32_ctypes\":[{\"version\":\"3.11\"}]}",
+                "readme_renderer": "{\"pip_tdb_311_readme_renderer\":[{\"version\":\"3.11\"}]}",
+                "requests": "{\"pip_tdb_311_requests\":[{\"version\":\"3.11\"}]}",
+                "requests_toolbelt": "{\"pip_tdb_311_requests_toolbelt\":[{\"version\":\"3.11\"}]}",
+                "rfc3986": "{\"pip_tdb_311_rfc3986\":[{\"version\":\"3.11\"}]}",
+                "rich": "{\"pip_tdb_311_rich\":[{\"version\":\"3.11\"}]}",
+                "secretstorage": "{\"pip_tdb_311_secretstorage\":[{\"version\":\"3.11\"}]}",
+                "setuptools": "{\"pip_tdb_311_setuptools\":[{\"version\":\"3.11\"}]}",
+                "six": "{\"pip_tdb_311_six\":[{\"version\":\"3.11\"}]}",
+                "tqdm": "{\"pip_tdb_311_tqdm\":[{\"version\":\"3.11\"}]}",
+                "twine": "{\"pip_tdb_311_twine\":[{\"version\":\"3.11\"}]}",
+                "typing_extensions": "{\"pip_tdb_311_typing_extensions\":[{\"version\":\"3.11\"}]}",
+                "urllib3": "{\"pip_tdb_311_urllib3\":[{\"version\":\"3.11\"}]}",
+                "webencodings": "{\"pip_tdb_311_webencodings\":[{\"version\":\"3.11\"}]}",
+                "wheel": "{\"pip_tdb_311_wheel\":[{\"version\":\"3.11\"}]}",
+                "zipp": "{\"pip_tdb_311_zipp\":[{\"version\":\"3.11\"}]}"
+              },
+              "packages": [
+                "bleach",
+                "certifi",
+                "cffi",
+                "chardet",
+                "charset_normalizer",
+                "colorama",
+                "cryptography",
+                "docutils",
+                "idna",
+                "importlib_metadata",
+                "importlib_resources",
+                "jaraco_classes",
+                "jeepney",
+                "keyring",
+                "markdown_it_py",
+                "mdurl",
+                "more_itertools",
+                "packaging",
+                "pkginfo",
+                "pycparser",
+                "pygments",
+                "pyparsing",
+                "readme_renderer",
+                "requests",
+                "requests_toolbelt",
+                "rfc3986",
+                "rich",
+                "secretstorage",
+                "setuptools",
+                "six",
+                "tqdm",
+                "twine",
+                "typing_extensions",
+                "urllib3",
+                "webencodings",
+                "wheel",
+                "zipp"
+              ],
+              "groups": {}
+            }
+          },
+          "pip_uploader": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
+            "attributes": {
+              "repo_name": "pip_uploader",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "certifi": "{\"pip_uploader_311_certifi\":[{\"version\":\"3.11\"}]}",
+                "charset_normalizer": "{\"pip_uploader_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
+                "idna": "{\"pip_uploader_311_idna\":[{\"version\":\"3.11\"}]}",
+                "requests": "{\"pip_uploader_311_requests\":[{\"version\":\"3.11\"}]}",
+                "urllib3": "{\"pip_uploader_311_urllib3\":[{\"version\":\"3.11\"}]}"
+              },
+              "packages": [
+                "certifi",
+                "charset_normalizer",
+                "idna",
+                "requests",
+                "urllib3"
               ],
               "groups": {}
             }
@@ -3729,115 +3838,6 @@
                 "typing_extensions",
                 "urllib3",
                 "zipp"
-              ],
-              "groups": {}
-            }
-          },
-          "pip_tdb": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
-            "attributes": {
-              "repo_name": "pip_tdb",
-              "extra_hub_aliases": {},
-              "whl_map": {
-                "bleach": "{\"pip_tdb_311_bleach\":[{\"version\":\"3.11\"}]}",
-                "certifi": "{\"pip_tdb_311_certifi\":[{\"version\":\"3.11\"}]}",
-                "cffi": "{\"pip_tdb_311_cffi\":[{\"version\":\"3.11\"}]}",
-                "chardet": "{\"pip_tdb_311_chardet\":[{\"version\":\"3.11\"}]}",
-                "charset_normalizer": "{\"pip_tdb_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
-                "colorama": "{\"pip_tdb_311_colorama\":[{\"version\":\"3.11\"}]}",
-                "cryptography": "{\"pip_tdb_311_cryptography\":[{\"version\":\"3.11\"}]}",
-                "docutils": "{\"pip_tdb_311_docutils\":[{\"version\":\"3.11\"}]}",
-                "idna": "{\"pip_tdb_311_idna\":[{\"version\":\"3.11\"}]}",
-                "importlib_metadata": "{\"pip_tdb_311_importlib_metadata\":[{\"version\":\"3.11\"}]}",
-                "importlib_resources": "{\"pip_tdb_311_importlib_resources\":[{\"version\":\"3.11\"}]}",
-                "jaraco_classes": "{\"pip_tdb_311_jaraco_classes\":[{\"version\":\"3.11\"}]}",
-                "jeepney": "{\"pip_tdb_311_jeepney\":[{\"version\":\"3.11\"}]}",
-                "keyring": "{\"pip_tdb_311_keyring\":[{\"version\":\"3.11\"}]}",
-                "markdown_it_py": "{\"pip_tdb_311_markdown_it_py\":[{\"version\":\"3.11\"}]}",
-                "mdurl": "{\"pip_tdb_311_mdurl\":[{\"version\":\"3.11\"}]}",
-                "more_itertools": "{\"pip_tdb_311_more_itertools\":[{\"version\":\"3.11\"}]}",
-                "packaging": "{\"pip_tdb_311_packaging\":[{\"version\":\"3.11\"}]}",
-                "pkginfo": "{\"pip_tdb_311_pkginfo\":[{\"version\":\"3.11\"}]}",
-                "pycparser": "{\"pip_tdb_311_pycparser\":[{\"version\":\"3.11\"}]}",
-                "pygments": "{\"pip_tdb_311_pygments\":[{\"version\":\"3.11\"}]}",
-                "pyparsing": "{\"pip_tdb_311_pyparsing\":[{\"version\":\"3.11\"}]}",
-                "pywin32_ctypes": "{\"pip_tdb_311_pywin32_ctypes\":[{\"version\":\"3.11\"}]}",
-                "readme_renderer": "{\"pip_tdb_311_readme_renderer\":[{\"version\":\"3.11\"}]}",
-                "requests": "{\"pip_tdb_311_requests\":[{\"version\":\"3.11\"}]}",
-                "requests_toolbelt": "{\"pip_tdb_311_requests_toolbelt\":[{\"version\":\"3.11\"}]}",
-                "rfc3986": "{\"pip_tdb_311_rfc3986\":[{\"version\":\"3.11\"}]}",
-                "rich": "{\"pip_tdb_311_rich\":[{\"version\":\"3.11\"}]}",
-                "secretstorage": "{\"pip_tdb_311_secretstorage\":[{\"version\":\"3.11\"}]}",
-                "setuptools": "{\"pip_tdb_311_setuptools\":[{\"version\":\"3.11\"}]}",
-                "six": "{\"pip_tdb_311_six\":[{\"version\":\"3.11\"}]}",
-                "tqdm": "{\"pip_tdb_311_tqdm\":[{\"version\":\"3.11\"}]}",
-                "twine": "{\"pip_tdb_311_twine\":[{\"version\":\"3.11\"}]}",
-                "typing_extensions": "{\"pip_tdb_311_typing_extensions\":[{\"version\":\"3.11\"}]}",
-                "urllib3": "{\"pip_tdb_311_urllib3\":[{\"version\":\"3.11\"}]}",
-                "webencodings": "{\"pip_tdb_311_webencodings\":[{\"version\":\"3.11\"}]}",
-                "wheel": "{\"pip_tdb_311_wheel\":[{\"version\":\"3.11\"}]}",
-                "zipp": "{\"pip_tdb_311_zipp\":[{\"version\":\"3.11\"}]}"
-              },
-              "packages": [
-                "bleach",
-                "certifi",
-                "cffi",
-                "chardet",
-                "charset_normalizer",
-                "colorama",
-                "cryptography",
-                "docutils",
-                "idna",
-                "importlib_metadata",
-                "importlib_resources",
-                "jaraco_classes",
-                "jeepney",
-                "keyring",
-                "markdown_it_py",
-                "mdurl",
-                "more_itertools",
-                "packaging",
-                "pkginfo",
-                "pycparser",
-                "pygments",
-                "pyparsing",
-                "readme_renderer",
-                "requests",
-                "requests_toolbelt",
-                "rfc3986",
-                "rich",
-                "secretstorage",
-                "setuptools",
-                "six",
-                "tqdm",
-                "twine",
-                "typing_extensions",
-                "urllib3",
-                "webencodings",
-                "wheel",
-                "zipp"
-              ],
-              "groups": {}
-            }
-          },
-          "pip_uploader": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
-            "attributes": {
-              "repo_name": "pip_uploader",
-              "extra_hub_aliases": {},
-              "whl_map": {
-                "certifi": "{\"pip_uploader_311_certifi\":[{\"version\":\"3.11\"}]}",
-                "charset_normalizer": "{\"pip_uploader_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
-                "idna": "{\"pip_uploader_311_idna\":[{\"version\":\"3.11\"}]}",
-                "requests": "{\"pip_uploader_311_requests\":[{\"version\":\"3.11\"}]}",
-                "urllib3": "{\"pip_uploader_311_urllib3\":[{\"version\":\"3.11\"}]}"
-              },
-              "packages": [
-                "certifi",
-                "charset_normalizer",
-                "idna",
-                "requests",
-                "urllib3"
               ],
               "groups": {}
             }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3182,390 +3182,390 @@
               "requirement": "zipp==3.15.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_bleach": {
+          "pip_tdb_311_bleach": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "bleach==6.0.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_certifi": {
+          "pip_tdb_311_certifi": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "certifi==2022.12.7"
             }
           },
-          "typedb_bazel_distribution_pip_311_cffi": {
+          "pip_tdb_311_cffi": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "cffi==1.15.1"
             }
           },
-          "typedb_bazel_distribution_pip_311_chardet": {
+          "pip_tdb_311_chardet": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "chardet==5.1.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_charset_normalizer": {
+          "pip_tdb_311_charset_normalizer": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "charset-normalizer==3.0.1"
             }
           },
-          "typedb_bazel_distribution_pip_311_colorama": {
+          "pip_tdb_311_colorama": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "colorama==0.4.6"
             }
           },
-          "typedb_bazel_distribution_pip_311_cryptography": {
+          "pip_tdb_311_cryptography": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "cryptography==39.0.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_docutils": {
+          "pip_tdb_311_docutils": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "docutils==0.19"
             }
           },
-          "typedb_bazel_distribution_pip_311_idna": {
+          "pip_tdb_311_idna": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "idna==3.4"
             }
           },
-          "typedb_bazel_distribution_pip_311_importlib_metadata": {
+          "pip_tdb_311_importlib_metadata": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "importlib-metadata==6.0.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_importlib_resources": {
+          "pip_tdb_311_importlib_resources": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "importlib-resources==5.10.2"
             }
           },
-          "typedb_bazel_distribution_pip_311_jaraco_classes": {
+          "pip_tdb_311_jaraco_classes": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "jaraco-classes==3.2.3"
             }
           },
-          "typedb_bazel_distribution_pip_311_jeepney": {
+          "pip_tdb_311_jeepney": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "jeepney==0.8.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_keyring": {
+          "pip_tdb_311_keyring": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "keyring==23.13.1"
             }
           },
-          "typedb_bazel_distribution_pip_311_markdown_it_py": {
+          "pip_tdb_311_markdown_it_py": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "markdown-it-py==2.1.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_mdurl": {
+          "pip_tdb_311_mdurl": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "mdurl==0.1.2"
             }
           },
-          "typedb_bazel_distribution_pip_311_more_itertools": {
+          "pip_tdb_311_more_itertools": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "more-itertools==9.0.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_packaging": {
+          "pip_tdb_311_packaging": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "packaging==23.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_pkginfo": {
+          "pip_tdb_311_pkginfo": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "pkginfo==1.9.6"
             }
           },
-          "typedb_bazel_distribution_pip_311_pycparser": {
+          "pip_tdb_311_pycparser": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "pycparser==2.21"
             }
           },
-          "typedb_bazel_distribution_pip_311_pygments": {
+          "pip_tdb_311_pygments": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "pygments==2.14.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_pyparsing": {
+          "pip_tdb_311_pyparsing": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "pyparsing==3.0.9"
             }
           },
-          "typedb_bazel_distribution_pip_311_pywin32_ctypes": {
+          "pip_tdb_311_pywin32_ctypes": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "pywin32-ctypes==0.2.2; sys_platform == 'win32'"
             }
           },
-          "typedb_bazel_distribution_pip_311_readme_renderer": {
+          "pip_tdb_311_readme_renderer": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "readme-renderer==37.3"
             }
           },
-          "typedb_bazel_distribution_pip_311_requests": {
+          "pip_tdb_311_requests": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "requests==2.28.2"
             }
           },
-          "typedb_bazel_distribution_pip_311_requests_toolbelt": {
+          "pip_tdb_311_requests_toolbelt": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "requests-toolbelt==0.10.1"
             }
           },
-          "typedb_bazel_distribution_pip_311_rfc3986": {
+          "pip_tdb_311_rfc3986": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "rfc3986==2.0.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_rich": {
+          "pip_tdb_311_rich": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "rich==13.2.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_secretstorage": {
+          "pip_tdb_311_secretstorage": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "secretstorage==3.3.3"
             }
           },
-          "typedb_bazel_distribution_pip_311_setuptools": {
+          "pip_tdb_311_setuptools": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "setuptools==65.0.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_six": {
+          "pip_tdb_311_six": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "six==1.16.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_tqdm": {
+          "pip_tdb_311_tqdm": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "tqdm==4.64.1"
             }
           },
-          "typedb_bazel_distribution_pip_311_twine": {
+          "pip_tdb_311_twine": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "twine==4.0.2"
             }
           },
-          "typedb_bazel_distribution_pip_311_typing_extensions": {
+          "pip_tdb_311_typing_extensions": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "typing-extensions==4.4.0"
             }
           },
-          "typedb_bazel_distribution_pip_311_urllib3": {
+          "pip_tdb_311_urllib3": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "urllib3==1.26.14"
             }
           },
-          "typedb_bazel_distribution_pip_311_webencodings": {
+          "pip_tdb_311_webencodings": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "webencodings==0.5.1"
             }
           },
-          "typedb_bazel_distribution_pip_311_wheel": {
+          "pip_tdb_311_wheel": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "wheel==0.38.4"
             }
           },
-          "typedb_bazel_distribution_pip_311_zipp": {
+          "pip_tdb_311_zipp": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_pip//{name}:{target}",
+              "dep_template": "@pip_tdb//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_pip_311",
+              "repo": "pip_tdb_311",
               "requirement": "zipp==3.11.0"
             }
           },
-          "typedb_bazel_distribution_uploader_311_certifi": {
+          "pip_uploader_311_certifi": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_uploader//{name}:{target}",
+              "dep_template": "@pip_uploader//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_uploader_311",
+              "repo": "pip_uploader_311",
               "requirement": "certifi==2022.12.7"
             }
           },
-          "typedb_bazel_distribution_uploader_311_charset_normalizer": {
+          "pip_uploader_311_charset_normalizer": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_uploader//{name}:{target}",
+              "dep_template": "@pip_uploader//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_uploader_311",
+              "repo": "pip_uploader_311",
               "requirement": "charset-normalizer==3.0.1"
             }
           },
-          "typedb_bazel_distribution_uploader_311_idna": {
+          "pip_uploader_311_idna": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_uploader//{name}:{target}",
+              "dep_template": "@pip_uploader//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_uploader_311",
+              "repo": "pip_uploader_311",
               "requirement": "idna==3.4"
             }
           },
-          "typedb_bazel_distribution_uploader_311_requests": {
+          "pip_uploader_311_requests": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_uploader//{name}:{target}",
+              "dep_template": "@pip_uploader//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_uploader_311",
+              "repo": "pip_uploader_311",
               "requirement": "requests==2.28.2"
             }
           },
-          "typedb_bazel_distribution_uploader_311_urllib3": {
+          "pip_uploader_311_urllib3": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
-              "dep_template": "@typedb_bazel_distribution_uploader//{name}:{target}",
+              "dep_template": "@pip_uploader//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
-              "repo": "typedb_bazel_distribution_uploader_311",
+              "repo": "pip_uploader_311",
               "requirement": "urllib3==1.26.14"
             }
           },
@@ -3733,50 +3733,50 @@
               "groups": {}
             }
           },
-          "typedb_bazel_distribution_pip": {
+          "pip_tdb": {
             "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
             "attributes": {
-              "repo_name": "typedb_bazel_distribution_pip",
+              "repo_name": "pip_tdb",
               "extra_hub_aliases": {},
               "whl_map": {
-                "bleach": "{\"typedb_bazel_distribution_pip_311_bleach\":[{\"version\":\"3.11\"}]}",
-                "certifi": "{\"typedb_bazel_distribution_pip_311_certifi\":[{\"version\":\"3.11\"}]}",
-                "cffi": "{\"typedb_bazel_distribution_pip_311_cffi\":[{\"version\":\"3.11\"}]}",
-                "chardet": "{\"typedb_bazel_distribution_pip_311_chardet\":[{\"version\":\"3.11\"}]}",
-                "charset_normalizer": "{\"typedb_bazel_distribution_pip_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
-                "colorama": "{\"typedb_bazel_distribution_pip_311_colorama\":[{\"version\":\"3.11\"}]}",
-                "cryptography": "{\"typedb_bazel_distribution_pip_311_cryptography\":[{\"version\":\"3.11\"}]}",
-                "docutils": "{\"typedb_bazel_distribution_pip_311_docutils\":[{\"version\":\"3.11\"}]}",
-                "idna": "{\"typedb_bazel_distribution_pip_311_idna\":[{\"version\":\"3.11\"}]}",
-                "importlib_metadata": "{\"typedb_bazel_distribution_pip_311_importlib_metadata\":[{\"version\":\"3.11\"}]}",
-                "importlib_resources": "{\"typedb_bazel_distribution_pip_311_importlib_resources\":[{\"version\":\"3.11\"}]}",
-                "jaraco_classes": "{\"typedb_bazel_distribution_pip_311_jaraco_classes\":[{\"version\":\"3.11\"}]}",
-                "jeepney": "{\"typedb_bazel_distribution_pip_311_jeepney\":[{\"version\":\"3.11\"}]}",
-                "keyring": "{\"typedb_bazel_distribution_pip_311_keyring\":[{\"version\":\"3.11\"}]}",
-                "markdown_it_py": "{\"typedb_bazel_distribution_pip_311_markdown_it_py\":[{\"version\":\"3.11\"}]}",
-                "mdurl": "{\"typedb_bazel_distribution_pip_311_mdurl\":[{\"version\":\"3.11\"}]}",
-                "more_itertools": "{\"typedb_bazel_distribution_pip_311_more_itertools\":[{\"version\":\"3.11\"}]}",
-                "packaging": "{\"typedb_bazel_distribution_pip_311_packaging\":[{\"version\":\"3.11\"}]}",
-                "pkginfo": "{\"typedb_bazel_distribution_pip_311_pkginfo\":[{\"version\":\"3.11\"}]}",
-                "pycparser": "{\"typedb_bazel_distribution_pip_311_pycparser\":[{\"version\":\"3.11\"}]}",
-                "pygments": "{\"typedb_bazel_distribution_pip_311_pygments\":[{\"version\":\"3.11\"}]}",
-                "pyparsing": "{\"typedb_bazel_distribution_pip_311_pyparsing\":[{\"version\":\"3.11\"}]}",
-                "pywin32_ctypes": "{\"typedb_bazel_distribution_pip_311_pywin32_ctypes\":[{\"version\":\"3.11\"}]}",
-                "readme_renderer": "{\"typedb_bazel_distribution_pip_311_readme_renderer\":[{\"version\":\"3.11\"}]}",
-                "requests": "{\"typedb_bazel_distribution_pip_311_requests\":[{\"version\":\"3.11\"}]}",
-                "requests_toolbelt": "{\"typedb_bazel_distribution_pip_311_requests_toolbelt\":[{\"version\":\"3.11\"}]}",
-                "rfc3986": "{\"typedb_bazel_distribution_pip_311_rfc3986\":[{\"version\":\"3.11\"}]}",
-                "rich": "{\"typedb_bazel_distribution_pip_311_rich\":[{\"version\":\"3.11\"}]}",
-                "secretstorage": "{\"typedb_bazel_distribution_pip_311_secretstorage\":[{\"version\":\"3.11\"}]}",
-                "setuptools": "{\"typedb_bazel_distribution_pip_311_setuptools\":[{\"version\":\"3.11\"}]}",
-                "six": "{\"typedb_bazel_distribution_pip_311_six\":[{\"version\":\"3.11\"}]}",
-                "tqdm": "{\"typedb_bazel_distribution_pip_311_tqdm\":[{\"version\":\"3.11\"}]}",
-                "twine": "{\"typedb_bazel_distribution_pip_311_twine\":[{\"version\":\"3.11\"}]}",
-                "typing_extensions": "{\"typedb_bazel_distribution_pip_311_typing_extensions\":[{\"version\":\"3.11\"}]}",
-                "urllib3": "{\"typedb_bazel_distribution_pip_311_urllib3\":[{\"version\":\"3.11\"}]}",
-                "webencodings": "{\"typedb_bazel_distribution_pip_311_webencodings\":[{\"version\":\"3.11\"}]}",
-                "wheel": "{\"typedb_bazel_distribution_pip_311_wheel\":[{\"version\":\"3.11\"}]}",
-                "zipp": "{\"typedb_bazel_distribution_pip_311_zipp\":[{\"version\":\"3.11\"}]}"
+                "bleach": "{\"pip_tdb_311_bleach\":[{\"version\":\"3.11\"}]}",
+                "certifi": "{\"pip_tdb_311_certifi\":[{\"version\":\"3.11\"}]}",
+                "cffi": "{\"pip_tdb_311_cffi\":[{\"version\":\"3.11\"}]}",
+                "chardet": "{\"pip_tdb_311_chardet\":[{\"version\":\"3.11\"}]}",
+                "charset_normalizer": "{\"pip_tdb_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
+                "colorama": "{\"pip_tdb_311_colorama\":[{\"version\":\"3.11\"}]}",
+                "cryptography": "{\"pip_tdb_311_cryptography\":[{\"version\":\"3.11\"}]}",
+                "docutils": "{\"pip_tdb_311_docutils\":[{\"version\":\"3.11\"}]}",
+                "idna": "{\"pip_tdb_311_idna\":[{\"version\":\"3.11\"}]}",
+                "importlib_metadata": "{\"pip_tdb_311_importlib_metadata\":[{\"version\":\"3.11\"}]}",
+                "importlib_resources": "{\"pip_tdb_311_importlib_resources\":[{\"version\":\"3.11\"}]}",
+                "jaraco_classes": "{\"pip_tdb_311_jaraco_classes\":[{\"version\":\"3.11\"}]}",
+                "jeepney": "{\"pip_tdb_311_jeepney\":[{\"version\":\"3.11\"}]}",
+                "keyring": "{\"pip_tdb_311_keyring\":[{\"version\":\"3.11\"}]}",
+                "markdown_it_py": "{\"pip_tdb_311_markdown_it_py\":[{\"version\":\"3.11\"}]}",
+                "mdurl": "{\"pip_tdb_311_mdurl\":[{\"version\":\"3.11\"}]}",
+                "more_itertools": "{\"pip_tdb_311_more_itertools\":[{\"version\":\"3.11\"}]}",
+                "packaging": "{\"pip_tdb_311_packaging\":[{\"version\":\"3.11\"}]}",
+                "pkginfo": "{\"pip_tdb_311_pkginfo\":[{\"version\":\"3.11\"}]}",
+                "pycparser": "{\"pip_tdb_311_pycparser\":[{\"version\":\"3.11\"}]}",
+                "pygments": "{\"pip_tdb_311_pygments\":[{\"version\":\"3.11\"}]}",
+                "pyparsing": "{\"pip_tdb_311_pyparsing\":[{\"version\":\"3.11\"}]}",
+                "pywin32_ctypes": "{\"pip_tdb_311_pywin32_ctypes\":[{\"version\":\"3.11\"}]}",
+                "readme_renderer": "{\"pip_tdb_311_readme_renderer\":[{\"version\":\"3.11\"}]}",
+                "requests": "{\"pip_tdb_311_requests\":[{\"version\":\"3.11\"}]}",
+                "requests_toolbelt": "{\"pip_tdb_311_requests_toolbelt\":[{\"version\":\"3.11\"}]}",
+                "rfc3986": "{\"pip_tdb_311_rfc3986\":[{\"version\":\"3.11\"}]}",
+                "rich": "{\"pip_tdb_311_rich\":[{\"version\":\"3.11\"}]}",
+                "secretstorage": "{\"pip_tdb_311_secretstorage\":[{\"version\":\"3.11\"}]}",
+                "setuptools": "{\"pip_tdb_311_setuptools\":[{\"version\":\"3.11\"}]}",
+                "six": "{\"pip_tdb_311_six\":[{\"version\":\"3.11\"}]}",
+                "tqdm": "{\"pip_tdb_311_tqdm\":[{\"version\":\"3.11\"}]}",
+                "twine": "{\"pip_tdb_311_twine\":[{\"version\":\"3.11\"}]}",
+                "typing_extensions": "{\"pip_tdb_311_typing_extensions\":[{\"version\":\"3.11\"}]}",
+                "urllib3": "{\"pip_tdb_311_urllib3\":[{\"version\":\"3.11\"}]}",
+                "webencodings": "{\"pip_tdb_311_webencodings\":[{\"version\":\"3.11\"}]}",
+                "wheel": "{\"pip_tdb_311_wheel\":[{\"version\":\"3.11\"}]}",
+                "zipp": "{\"pip_tdb_311_zipp\":[{\"version\":\"3.11\"}]}"
               },
               "packages": [
                 "bleach",
@@ -3820,17 +3820,17 @@
               "groups": {}
             }
           },
-          "typedb_bazel_distribution_uploader": {
+          "pip_uploader": {
             "repoRuleId": "@@rules_python+//python/private/pypi:hub_repository.bzl%hub_repository",
             "attributes": {
-              "repo_name": "typedb_bazel_distribution_uploader",
+              "repo_name": "pip_uploader",
               "extra_hub_aliases": {},
               "whl_map": {
-                "certifi": "{\"typedb_bazel_distribution_uploader_311_certifi\":[{\"version\":\"3.11\"}]}",
-                "charset_normalizer": "{\"typedb_bazel_distribution_uploader_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
-                "idna": "{\"typedb_bazel_distribution_uploader_311_idna\":[{\"version\":\"3.11\"}]}",
-                "requests": "{\"typedb_bazel_distribution_uploader_311_requests\":[{\"version\":\"3.11\"}]}",
-                "urllib3": "{\"typedb_bazel_distribution_uploader_311_urllib3\":[{\"version\":\"3.11\"}]}"
+                "certifi": "{\"pip_uploader_311_certifi\":[{\"version\":\"3.11\"}]}",
+                "charset_normalizer": "{\"pip_uploader_311_charset_normalizer\":[{\"version\":\"3.11\"}]}",
+                "idna": "{\"pip_uploader_311_idna\":[{\"version\":\"3.11\"}]}",
+                "requests": "{\"pip_uploader_311_requests\":[{\"version\":\"3.11\"}]}",
+                "urllib3": "{\"pip_uploader_311_urllib3\":[{\"version\":\"3.11\"}]}"
               },
               "packages": [
                 "certifi",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,10 +57,10 @@ maven_install(
     fetch_sources = True,
 )
 
-# Load @typedb_bazel_distribution_pip
-load("//pip:deps.bzl", "typedb_bazel_distribution_pip")
-typedb_bazel_distribution_pip()
-load("@typedb_bazel_distribution_pip//:requirements.bzl", pip_install_deps = "install_deps")
+# Load @pip_tdb
+load("//pip:deps.bzl", "pip_tdb")
+pip_tdb()
+load("@pip_tdb//:requirements.bzl", pip_install_deps = "install_deps")
 pip_install_deps()
 
 # Load //docs
@@ -103,8 +103,8 @@ http_archive(
 load("@bazel_stardoc//:setup.bzl", "stardoc_repositories")
 stardoc_repositories()
 
-# Load @typedb_bazel_distribution_uploader
-load("//common/uploader:deps.bzl", "typedb_bazel_distribution_uploader")
-typedb_bazel_distribution_uploader()
-load("@typedb_bazel_distribution_uploader//:requirements.bzl", uploader_install_deps = "install_deps")
+# Load @pip_uploader
+load("//common/uploader:deps.bzl", "pip_uploader")
+pip_uploader()
+load("@pip_uploader//:requirements.bzl", uploader_install_deps = "install_deps")
 uploader_install_deps()

--- a/common/package_versioning/BUILD
+++ b/common/package_versioning/BUILD
@@ -17,32 +17,10 @@
 # under the License.
 #
 
-exports_files(["archiver.py", "common.py"])
-
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 bzl_library(
     name = "lib",
     srcs = [ "rules.bzl" ],
-    deps = [
-        "//common/assemble_versioned:lib",
-        "//common/checksum:lib",
-        "//common/generate_json_config:lib",
-        "//common/java_deps:lib",
-        "//common/rename:lib",
-        "//common/package_versioning:lib",
-        "//common/targz:lib",
-        "//common/tgz2zip:lib",
-        "//common/workspace_refs:lib",
-        "//common/zip:lib"
-    ],
     visibility = ["//visibility:public"]
-)
-
-kt_jvm_library(
-    name = "common",
-    srcs = glob(["*.kt"]),
-    deps = [],
-    visibility = ["//visibility:public"],
 )

--- a/common/package_versioning/rules.bzl
+++ b/common/package_versioning/rules.bzl
@@ -17,32 +17,13 @@
 # under the License.
 #
 
-exports_files(["archiver.py", "common.py"])
+load("@rules_pkg//pkg:providers.bzl", "PackageVariablesInfo")
 
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+def _package_version_vars_impl(ctx):
+    version = ctx.var.get("version", "0.0.0")
+    return PackageVariablesInfo(values = {"version": version})
 
-bzl_library(
-    name = "lib",
-    srcs = [ "rules.bzl" ],
-    deps = [
-        "//common/assemble_versioned:lib",
-        "//common/checksum:lib",
-        "//common/generate_json_config:lib",
-        "//common/java_deps:lib",
-        "//common/rename:lib",
-        "//common/package_versioning:lib",
-        "//common/targz:lib",
-        "//common/tgz2zip:lib",
-        "//common/workspace_refs:lib",
-        "//common/zip:lib"
-    ],
-    visibility = ["//visibility:public"]
-)
-
-kt_jvm_library(
-    name = "common",
-    srcs = glob(["*.kt"]),
-    deps = [],
-    visibility = ["//visibility:public"],
+package_version_vars = rule(
+    implementation = _package_version_vars_impl,
+    attrs = {}
 )

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -21,6 +21,7 @@ load("@typedb_bazel_distribution//common/assemble_versioned:rules.bzl", _assembl
 load("@typedb_bazel_distribution//common/checksum:rules.bzl", _checksum = "checksum")
 load("@typedb_bazel_distribution//common/generate_json_config:rules.bzl", _generate_json_config = "generate_json_config")
 load("@typedb_bazel_distribution//common/java_deps:rules.bzl", _java_deps = "java_deps")
+load("@typedb_bazel_distribution//common/package_versioning:rules.bzl", _package_version_vars = "package_version_vars")
 load("@typedb_bazel_distribution//common/tgz2zip:rules.bzl", _tgz2zip = "tgz2zip")
 load("@typedb_bazel_distribution//common/targz:rules.bzl", _assemble_targz = "assemble_targz")
 load("@typedb_bazel_distribution//common/workspace_refs:rules.bzl", _workspace_refs = "workspace_refs")
@@ -34,6 +35,7 @@ checksum = _checksum
 file_rename = _file_rename
 generate_json_config = _generate_json_config
 java_deps = _java_deps
+package_version_vars = _package_version_vars
 tgz2zip = _tgz2zip
 unzip_file = _unzip_file
 workspace_refs = _workspace_refs

--- a/common/uploader/BUILD
+++ b/common/uploader/BUILD
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-load("@typedb_bazel_distribution_uploader//:requirements.bzl", cloudsmith_requirement = "requirement")
+load("@pip_uploader//:requirements.bzl", cloudsmith_requirement = "requirement")
 
 py_library(
     name = "uploader",

--- a/common/uploader/deps.bzl
+++ b/common/uploader/deps.bzl
@@ -1,10 +1,10 @@
 load("@rules_python//python:pip.bzl", "pip_parse")
 
-def typedb_bazel_distribution_uploader(python_interpreter_target = None):
+def pip_uploader(python_interpreter_target = None):
     # Optionally specify the python interpreter to use instead of
     # e.g. @<toolchain_name>_host//:python
     pip_parse(
-        name = "typedb_bazel_distribution_uploader",
+        name = "pip_uploader",
         requirements_lock = "@typedb_bazel_distribution//common/uploader:requirements.txt",
         python_interpreter_target = python_interpreter_target
     )

--- a/doc_hub.bzl
+++ b/doc_hub.bzl
@@ -32,6 +32,8 @@ load("//common/assemble_versioned:rules.bzl", _assemble_versioned = "assemble_ve
 
 load("//common/checksum:rules.bzl", _checksum = "checksum")
 
+load("//common/package_versioning:rules.bzl", _package_version_vars = "package_version_vars")
+
 load("//common/generate_json_config:rules.bzl", _generate_json_config = "generate_json_config")
 
 load("//common/java_deps:rules.bzl",

--- a/pip/BUILD
+++ b/pip/BUILD
@@ -20,7 +20,7 @@
 exports_files(["replace_imports.py", "requirements.txt"])
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@typedb_bazel_distribution_pip//:requirements.bzl", typedb_bazel_distribution_requirement = "requirement")
+load("@pip_tdb//:requirements.bzl", typedb_bazel_distribution_requirement = "requirement")
 
 
 bzl_library(
@@ -29,7 +29,7 @@ bzl_library(
         "rules.bzl",
     ],
     deps = [
-        "@typedb_bazel_distribution_pip//:requirements.bzl",
+        "@pip_tdb//:requirements.bzl",
         "@rules_python//python:pip_bzl",
     ],
     visibility = ["//visibility:public"]

--- a/pip/deps.bzl
+++ b/pip/deps.bzl
@@ -3,8 +3,8 @@
 
 load("@rules_python//python:pip.bzl", "pip_parse")
 
-def typedb_bazel_distribution_pip():
+def pip_tdb():
     pip_parse(
-        name = "typedb_bazel_distribution_pip",
+        name = "pip_tdb",
         requirements_lock = "@typedb_bazel_distribution//pip:requirements.txt",
     )

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-load("@typedb_bazel_distribution_pip//:requirements.bzl", typedb_bazel_distribution_requirement = "requirement")
+load("@pip_tdb//:requirements.bzl", typedb_bazel_distribution_requirement = "requirement")
 
 
 def _python_repackage_impl(ctx):


### PR DESCRIPTION
## Implementation
Shorter pip names stop deployment scripts from breaking.
Adding a `PackageVariablesInfo`  for `rules_pkg` to template the version number into package names.