### PR TITLE
Towards updating the tools to read commit/tag from git_override

### DIFF
--- a/common/workspace_refs/rules.bzl
+++ b/common/workspace_refs/rules.bzl
@@ -19,18 +19,12 @@
 
 def _workspace_refs_impl(repository_ctx):
     repository_ctx.file('BUILD', content='exports_files(["refs.json"])', executable=False)
-    workspace_refs_dict = {
-        "commits": repository_ctx.attr.workspace_commit_dict,
-        "tags": repository_ctx.attr.workspace_tag_dict,
-    }
-    repository_ctx.file('refs.json', content=json.encode(workspace_refs_dict), executable=False)
-
+    repository_ctx.file('refs.json', content=json.encode(repository_ctx.attr.workspace_refs), executable=False)
 
 _workspace_refs = repository_rule(
     implementation = _workspace_refs_impl,
     attrs = {
-        'workspace_commit_dict': attr.string_dict(),
-        'workspace_tag_dict': attr.string_dict(),
+        'workspace_refs': attr.string_list(),
     },
 )
 


### PR DESCRIPTION
## Usage and product changes
Simplifies the workspace refs to only mention the repo, and the versions are inferred using `bazel mod show_repo <repo>`

## Motivation
Avoid the redundant declaration which often goes out of sync
